### PR TITLE
移除usb驱动对于USB_CLASS_AUDIO接口的控制

### DIFF
--- a/app/src/main/java/com/limelight/binding/input/driver/AbstractXboxController.java
+++ b/app/src/main/java/com/limelight/binding/input/driver/AbstractXboxController.java
@@ -101,9 +101,14 @@ public abstract class AbstractXboxController extends AbstractController {
 
     public boolean start() {
         ifaces.clear();
-        // Force claim all interfaces
+        // Force claim all interfaces except audio so the system can handle the headset jack
         for (int i = 0; i < device.getInterfaceCount(); i++) {
             UsbInterface iface = device.getInterface(i);
+
+            // Let the OS own the USB audio interface so headset audio keeps working
+            if (iface.getInterfaceClass() == UsbConstants.USB_CLASS_AUDIO) {
+                continue;
+            }
 
             if (!connection.claimInterface(iface, true)) {
                 LimeLog.warning("Failed to claim interfaces");


### PR DESCRIPTION
目前xbox360controller的usb驱动实现没有正确处理USB_CLASS_AUDIO接口
在启用usb驱动时使系统保持控制该接口以正常接受手机应用的声音
仅在雷蛇骑仕v3pro上测试有效