### PR TITLE
给软键盘添加 InputConnection，修复 Gboard 中文键盘退化为 QWERTY 键盘的问题

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -93,6 +93,7 @@ import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 import android.view.ViewParent;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.view.inputmethod.InputMethodManager;
@@ -1579,6 +1580,34 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         return (byte) modifierFlags;
     }
 
+    private boolean isSoftKeyboardVisible() {
+        View decorView = getWindow().getDecorView();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsets rootInsets = decorView.getRootWindowInsets();
+            return rootInsets != null && rootInsets.isVisible(WindowInsets.Type.ime());
+        }
+
+        Rect visibleFrame = new Rect();
+        decorView.getWindowVisibleDisplayFrame(visibleFrame);
+        int keyboardHeight = decorView.getHeight() - visibleFrame.bottom;
+        return keyboardHeight > decorView.getHeight() * 0.15f;
+    }
+
+    private void sendVirtualKeyboardKey(int keyCode, byte keyDirection) {
+        short translated = keyboardTranslator.translate(keyCode, KeyCharacterMap.VIRTUAL_KEYBOARD);
+        if (translated == 0) {
+            return;
+        }
+
+        conn.sendKeyboardInput(translated, keyDirection, getModifierState(),
+                keyboardTranslator.hasNormalizedMapping(keyCode, KeyCharacterMap.VIRTUAL_KEYBOARD) ? 0 : MoonBridge.SS_KBE_FLAG_NON_NORMALIZED);
+    }
+
+    private void sendVirtualKeyboardKeyPress(int keyCode) {
+        sendVirtualKeyboardKey(keyCode, KeyboardPacket.KEY_DOWN);
+        sendVirtualKeyboardKey(keyCode, KeyboardPacket.KEY_UP);
+    }
+
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         return handleKeyDown(event) || super.onKeyDown(keyCode, event);
@@ -1747,6 +1776,30 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         return true;
     }
 
+    @Override
+    public void handleCommittedText(CharSequence text) {
+        if (!grabbedInput || text == null || text.length() == 0) {
+            return;
+        }
+
+        // 组合输入期间的文本留在本地，只有确认提交后才转发到远端。
+        conn.sendUtf8Text(text.toString());
+    }
+
+    @Override
+    public void handleDeleteSurroundingText(int beforeLength, int afterLength) {
+        if (!grabbedInput) {
+            return;
+        }
+
+        for (int i = 0; i < beforeLength; i++) {
+            sendVirtualKeyboardKeyPress(KeyEvent.KEYCODE_DEL);
+        }
+        for (int i = 0; i < afterLength; i++) {
+            sendVirtualKeyboardKeyPress(KeyEvent.KEYCODE_FORWARD_DEL);
+        }
+    }
+
     private TouchContext getTouchContext(int actionIndex)
     {
         if (actionIndex < touchContextMap.length) {
@@ -1761,7 +1814,20 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     public void toggleKeyboard() {
         LimeLog.info("Toggling keyboard overlay");
         InputMethodManager inputManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-        inputManager.toggleSoftInput(0, 0);
+        if (isSoftKeyboardVisible()) {
+            inputManager.hideSoftInputFromWindow(streamView.getWindowToken(), 0);
+            streamView.setImeInputConnectionActive(false);
+            inputManager.restartInput(streamView);
+            return;
+        }
+
+        // 先激活 StreamView 的 InputConnection，再请求显示软键盘。
+        streamView.setImeInputConnectionActive(true);
+        streamView.post(() -> {
+            streamView.requestFocus();
+            inputManager.restartInput(streamView);
+            inputManager.showSoftInput(streamView, InputMethodManager.SHOW_IMPLICIT);
+        });
     }
 
     private byte getLiTouchTypeFromEvent(MotionEvent event) {

--- a/app/src/main/java/com/limelight/ui/StreamView.java
+++ b/app/src/main/java/com/limelight/ui/StreamView.java
@@ -2,6 +2,9 @@ package com.limelight.ui;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.Selection;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
@@ -9,10 +12,16 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.SurfaceView;
 import android.view.ViewGroup;
+import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 
 public class StreamView extends SurfaceView {
     private double desiredAspectRatio;
     private InputCallbacks inputCallbacks;
+    // 仅作为 IME 的临时编辑缓冲区使用，组合输入不直接同步到远端
+    private final Editable imeEditable = Editable.Factory.getInstance().newEditable("");
+    private boolean imeInputConnectionActive;
 
 
     private boolean enableZoomAndPan = false;  // 开关变量，控制缩放和平移功能
@@ -32,6 +41,17 @@ public class StreamView extends SurfaceView {
 
     public void setInputCallbacks(InputCallbacks callbacks) {
         this.inputCallbacks = callbacks;
+    }
+
+    public void setImeInputConnectionActive(boolean active) {
+        this.imeInputConnectionActive = active;
+        if (!this.imeInputConnectionActive) {
+            clearImeEditable();
+        }
+    }
+
+    public boolean isImeInputConnectionActive() {
+        return imeInputConnectionActive;
     }
 
     public StreamView(Context context) {
@@ -85,7 +105,43 @@ public class StreamView extends SurfaceView {
     }
 
     @Override
+    public boolean onCheckIsTextEditor() {
+        return isImeInputConnectionActive();
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        if (!isImeInputConnectionActive()) {
+            return super.onCreateInputConnection(outAttrs);
+        }
+
+        // 只在显式打开软键盘时把 StreamView 暂时暴露为文本编辑器，
+        // 避免进入串流界面后自动弹出输入法。
+        outAttrs.inputType = InputType.TYPE_CLASS_TEXT |
+                InputType.TYPE_TEXT_FLAG_AUTO_CORRECT |
+                InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN | EditorInfo.IME_ACTION_NONE;
+        int selectionStart = Selection.getSelectionStart(imeEditable);
+        int selectionEnd = Selection.getSelectionEnd(imeEditable);
+        if (selectionStart < 0 || selectionEnd < 0) {
+            selectionStart = imeEditable.length();
+            selectionEnd = imeEditable.length();
+            Selection.setSelection(imeEditable, selectionEnd);
+        }
+        outAttrs.initialSelStart = selectionStart;
+        outAttrs.initialSelEnd = selectionEnd;
+        return new StreamInputConnection();
+    }
+
+    @Override
     public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (isImeInputConnectionActive() && keyCode == KeyEvent.KEYCODE_BACK) {
+            if (event.getAction() == KeyEvent.ACTION_UP) {
+                setImeInputConnectionActive(false);
+            }
+            return super.onKeyPreIme(keyCode, event);
+        }
+
         // This callbacks allows us to override dumb IME behavior like when
         // Samsung's default keyboard consumes Shift+Space.
         if (inputCallbacks != null) {
@@ -107,6 +163,8 @@ public class StreamView extends SurfaceView {
     public interface InputCallbacks {
         boolean handleKeyUp(KeyEvent event);
         boolean handleKeyDown(KeyEvent event);
+        void handleCommittedText(CharSequence text);
+        void handleDeleteSurroundingText(int beforeLength, int afterLength);
     }
 
     public void setEnableZoomAndPan(boolean enableZoomAndPan) {
@@ -211,5 +269,73 @@ public class StreamView extends SurfaceView {
         return scaleFactor;
     }
 
+    private void clearImeEditable() {
+        imeEditable.clear();
+        Selection.setSelection(imeEditable, 0);
+    }
+
+    private boolean hasEditableText() {
+        return imeEditable.length() > 0;
+    }
+
+    private final class StreamInputConnection extends BaseInputConnection {
+        private StreamInputConnection() {
+            super(StreamView.this, true);
+            Selection.setSelection(imeEditable, imeEditable.length());
+        }
+
+        @Override
+        public Editable getEditable() {
+            return imeEditable;
+        }
+
+        @Override
+        public boolean commitText(CharSequence text, int newCursorPosition) {
+            boolean handled = super.commitText(text, newCursorPosition);
+            if (inputCallbacks != null && text != null && text.length() > 0) {
+                // 只把最终提交的文本发送给远端，避免与组合输入阶段重复。
+                inputCallbacks.handleCommittedText(text);
+            }
+            clearImeEditable();
+            return handled;
+        }
+
+        @Override
+        public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+            if (hasEditableText()) {
+                return super.deleteSurroundingText(beforeLength, afterLength);
+            }
+
+            if (inputCallbacks != null) {
+                // 当本地缓冲区为空时，把删除操作映射为远端退格/前删按键。
+                inputCallbacks.handleDeleteSurroundingText(beforeLength, afterLength);
+            }
+            return true;
+        }
+
+        @Override
+        public boolean finishComposingText() {
+            boolean handled = super.finishComposingText();
+            if (!hasEditableText()) {
+                clearImeEditable();
+            }
+            return handled;
+        }
+
+        @Override
+        public boolean sendKeyEvent(KeyEvent event) {
+            if (inputCallbacks == null) {
+                return super.sendKeyEvent(event);
+            }
+
+            if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                return inputCallbacks.handleKeyDown(event);
+            }
+            else if (event.getAction() == KeyEvent.ACTION_UP) {
+                return inputCallbacks.handleKeyUp(event);
+            }
+            return super.sendKeyEvent(event);
+        }
+    }
 
 }


### PR DESCRIPTION
## 问题说明

当前软键盘仅通过 `toggleSoftInput()` 弹出时，**Gboard**在串流界面中无法获得完整的输入上下文，导致中文拼音九键等会退化为基础 QWERTY 键盘，影响中文输入体验。

## 修复内容

本次修改为 `StreamView` 按需提供 `InputConnection`，让输入法在显式打开软键盘时能够获得有效的文本输入连接。

## 修复效果

修复后，Gboard 在串流场景下可以正常使用中文拼音输入，不再退化为基础 QWERTY 键盘。

## 验证情况

已验证以下场景：

- 串流界面手动打开、关闭软键盘
- Gboard 中文键盘输入，其他主流输入法软键盘输入
- 空格、退格、回车键正常工作

## 补充说明

当前260302的源码似乎没有完全提交，导致编译时会提示缺少ui/gamepad/GyroView.java文件，本PR只包含修复相关内容，编译时使用占位文件，提交不涉及缺失文件。

再次感谢大佬的工作。本PR在Codespaces中使用Codex完成，如果大佬检查后未发现问题，请考虑在之后的发布中合并🙏
