### PR TITLE
Restore auto reconnect after returning from background

### DIFF
--- a/app/src/main/java/com/limelight/AppView.java
+++ b/app/src/main/java/com/limelight/AppView.java
@@ -20,6 +20,7 @@ import com.limelight.preferences.PreferenceConfiguration;
 import com.limelight.ui.AdapterFragment;
 import com.limelight.ui.AdapterFragmentCallbacks;
 import com.limelight.ui.gamemenu.GameDisplayFragment;
+import com.limelight.utils.AutoReconnectHelper;
 import com.limelight.utils.CacheHelper;
 import com.limelight.utils.Dialog;
 import com.limelight.utils.ServerHelper;
@@ -136,6 +137,12 @@ public class AppView extends Activity implements AdapterFragmentCallbacks {
 
                     // Start updates
                     startComputerUpdates();
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            tryAutoReconnect();
+                        }
+                    });
 
                     runOnUiThread(new Runnable() {
                         @Override
@@ -239,6 +246,13 @@ public class AppView extends Activity implements AdapterFragmentCallbacks {
 
                     return;
                 }
+
+                AppView.this.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        tryAutoReconnect();
+                    }
+                });
 
                 // App list is the same or empty
                 if (details.rawAppList == null || details.rawAppList.equals(lastRawApplist)) {
@@ -442,6 +456,7 @@ public class AppView extends Activity implements AdapterFragmentCallbacks {
 
         inForeground = true;
         startComputerUpdates();
+        tryAutoReconnect();
     }
 
     @Override
@@ -450,6 +465,14 @@ public class AppView extends Activity implements AdapterFragmentCallbacks {
 
         inForeground = false;
         stopComputerUpdates();
+    }
+
+    private void tryAutoReconnect() {
+        if (!inForeground || managerBinder == null) {
+            return;
+        }
+
+        AutoReconnectHelper.maybeResumeStream(this, managerBinder, uuidString);
     }
 
     @Override

--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -44,6 +44,7 @@ import com.limelight.ui.StreamView;
 import com.limelight.ui.floatingview.AXFloatingMagnetView;
 import com.limelight.ui.floatingview.AXFloatingView;
 import com.limelight.ui.floatingview.AXFloatingViewListener;
+import com.limelight.utils.AutoReconnectHelper;
 import com.limelight.utils.Dialog;
 import com.limelight.utils.RazerUtils;
 import com.limelight.utils.ServerHelper;
@@ -82,6 +83,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
+import android.os.PowerManager;
 import android.os.SystemClock;
 import android.preference.PreferenceManager;
 import android.text.SpannableString;
@@ -1516,8 +1518,14 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                         .apply();
             }
         }
-        if(prefConfig.enableScreenOnAuto!=0){
-            isAutoLink=true;
+        if (prefConfig.enableScreenOnAuto != 0 && !isFinishing()) {
+            PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
+            if (powerManager != null && powerManager.isInteractive()) {
+                AutoReconnectHelper.savePendingStream(getIntent());
+            }
+            else {
+                isAutoLink = true;
+            }
             return;
         }
         finish();

--- a/app/src/main/java/com/limelight/PcView.java
+++ b/app/src/main/java/com/limelight/PcView.java
@@ -25,6 +25,7 @@ import com.limelight.preferences.PreferenceConfiguration;
 import com.limelight.preferences.StreamSettings;
 import com.limelight.ui.AdapterFragment;
 import com.limelight.ui.AdapterFragmentCallbacks;
+import com.limelight.utils.AutoReconnectHelper;
 import com.limelight.utils.DeviceUtils;
 import com.limelight.utils.Dialog;
 import com.limelight.utils.HelpLauncher;
@@ -103,6 +104,12 @@ public class PcView extends Activity implements AdapterFragmentCallbacks {
 
                     // Start updates
                     startComputerUpdates();
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            tryAutoReconnect();
+                        }
+                    });
 
                     // Force a keypair to be generated early to avoid discovery delays
                     new AndroidCryptoProvider(PcView.this).getClientCertificate();
@@ -329,6 +336,13 @@ public class PcView extends Activity implements AdapterFragmentCallbacks {
                         if (details.pairState == PairState.PAIRED) {
                             shortcutHelper.createAppViewShortcutForOnlineHost(details);
                         }
+
+                        PcView.this.runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                tryAutoReconnect();
+                            }
+                        });
                     }
                 }
             });
@@ -372,6 +386,7 @@ public class PcView extends Activity implements AdapterFragmentCallbacks {
 
         inForeground = true;
         startComputerUpdates();
+        tryAutoReconnect();
     }
 
     @Override
@@ -387,6 +402,14 @@ public class PcView extends Activity implements AdapterFragmentCallbacks {
         super.onStop();
 
         Dialog.closeDialogs();
+    }
+
+    private void tryAutoReconnect() {
+        if (!inForeground || managerBinder == null) {
+            return;
+        }
+
+        AutoReconnectHelper.maybeResumeStream(this, managerBinder, null);
     }
 
     @Override

--- a/app/src/main/java/com/limelight/utils/AutoReconnectHelper.java
+++ b/app/src/main/java/com/limelight/utils/AutoReconnectHelper.java
@@ -1,0 +1,85 @@
+package com.limelight.utils;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import com.limelight.Game;
+import com.limelight.computers.ComputerManagerService;
+import com.limelight.nvstream.StreamConfiguration;
+import com.limelight.nvstream.http.ComputerDetails;
+import com.limelight.nvstream.http.NvApp;
+
+public final class AutoReconnectHelper {
+    private static PendingStream pendingStream;
+
+    private AutoReconnectHelper() {
+    }
+
+    public static synchronized void savePendingStream(Intent intent) {
+        if (intent == null) {
+            return;
+        }
+
+        String pcUuid = intent.getStringExtra(Game.EXTRA_PC_UUID);
+        int appId = intent.getIntExtra(Game.EXTRA_APP_ID, StreamConfiguration.INVALID_APP_ID);
+        if (pcUuid == null || appId == StreamConfiguration.INVALID_APP_ID) {
+            return;
+        }
+
+        pendingStream = new PendingStream(
+                pcUuid,
+                intent.getStringExtra(Game.EXTRA_APP_NAME),
+                appId,
+                intent.getBooleanExtra(Game.EXTRA_APP_HDR, false));
+    }
+
+    public static synchronized boolean maybeResumeStream(Activity activity,
+                                                         ComputerManagerService.ComputerManagerBinder managerBinder,
+                                                         String currentPcUuid) {
+        if (activity == null || managerBinder == null || pendingStream == null) {
+            return false;
+        }
+
+        if (currentPcUuid != null && !currentPcUuid.equalsIgnoreCase(pendingStream.pcUuid)) {
+            return false;
+        }
+
+        ComputerDetails computer = managerBinder.getComputer(pendingStream.pcUuid);
+        if (computer == null ||
+                computer.state != ComputerDetails.State.ONLINE ||
+                computer.activeAddress == null) {
+            return false;
+        }
+
+        int appId = pendingStream.appId;
+        if (appId == StreamConfiguration.INVALID_APP_ID) {
+            appId = computer.runningGameId;
+        }
+        if (appId == 0 || appId == StreamConfiguration.INVALID_APP_ID) {
+            return false;
+        }
+
+        NvApp app = new NvApp(
+                pendingStream.appName != null ? pendingStream.appName : "app",
+                appId,
+                pendingStream.appSupportsHdr);
+
+        pendingStream = null;
+        activity.startActivity(ServerHelper.createStartIntent(activity, app, computer, managerBinder));
+        return true;
+    }
+
+    private static final class PendingStream {
+        private final String pcUuid;
+        private final String appName;
+        private final int appId;
+        private final boolean appSupportsHdr;
+
+        private PendingStream(String pcUuid, String appName, int appId, boolean appSupportsHdr) {
+            this.pcUuid = pcUuid;
+            this.appName = appName;
+            this.appId = appId;
+            this.appSupportsHdr = appSupportsHdr;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
The existing auto reconnect flow is reliable for screen-off/screen-on, but returning from the background is different because the stream activity is no-history and should not try to recreate itself in-place.

This change keeps the original screen-on path intact, but adds a separate background-return path that stores the pending stream target and relaunches through the normal start intent from PcView/AppView.

## Result
Returning from the launcher/app switcher can reconnect directly back into the stream instead of stopping at the browse UI.