### PR TITLE
Fix IME composing backspace handling

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -35,11 +35,11 @@ import com.limelight.nvstream.http.NvApp;
 import com.limelight.nvstream.http.NvHTTP;
 import com.limelight.nvstream.input.KeyboardPacket;
 import com.limelight.nvstream.input.MouseButtonPacket;
-import com.limelight.nvstream.jni.MoonBridge;
 import com.limelight.preferences.GlPreferences;
 import com.limelight.preferences.PreferenceConfiguration;
 import com.limelight.ui.gamemenu.GameMenuFragment;
 import com.limelight.ui.GameGestures;
+import com.limelight.ui.StreamInputCallbacks;
 import com.limelight.ui.StreamView;
 import com.limelight.ui.floatingview.AXFloatingMagnetView;
 import com.limelight.ui.floatingview.AXFloatingView;
@@ -47,6 +47,7 @@ import com.limelight.ui.floatingview.AXFloatingViewListener;
 import com.limelight.utils.Dialog;
 import com.limelight.utils.RazerUtils;
 import com.limelight.utils.ServerHelper;
+import com.limelight.nvstream.jni.MoonBridge;
 import com.limelight.utils.ShortcutHelper;
 import com.limelight.utils.SpinnerDialog;
 import com.limelight.utils.UiHelper;
@@ -128,7 +129,7 @@ import java.util.Map;
 
 public class Game extends Activity implements SurfaceHolder.Callback,
         OnGenericMotionListener, OnTouchListener, NvConnectionListener, EvdevListener,
-        OnSystemUiVisibilityChangeListener, GameGestures, StreamView.InputCallbacks,
+        OnSystemUiVisibilityChangeListener, GameGestures, StreamInputCallbacks,
         PerfOverlayListener, UsbDriverService.UsbDriverStateListener, View.OnKeyListener{
     private static final float EXTERNAL_TOUCHPAD_SCROLL_FACTOR = 0.15f;
     private static final int REQUEST_RECORD_AUDIO_PERMISSION = 1001;
@@ -1873,6 +1874,36 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         return true;
     }
 
+    @Override
+    public void handleImeText(String text) {
+        if (conn == null || !grabbedInput || text == null || text.isEmpty()) {
+            return;
+        }
+
+        conn.sendUtf8Text(text);
+    }
+
+    @Override
+    public void handleImeBackspace(int count) {
+        sendImeKey((short) KeyboardTranslator.VK_BACK_SPACE, count);
+    }
+
+    @Override
+    public void handleImeForwardDelete(int count) {
+        sendImeKey((short) 0x2e, count);
+    }
+
+    private void sendImeKey(short keyCode, int count) {
+        if (conn == null || !grabbedInput || count <= 0) {
+            return;
+        }
+
+        for (int i = 0; i < count; i++) {
+            conn.sendKeyboardInput(keyCode, KeyboardPacket.KEY_DOWN, getModifierState(), (byte) 0);
+            conn.sendKeyboardInput(keyCode, KeyboardPacket.KEY_UP, getModifierState(), (byte) 0);
+        }
+    }
+
     private TouchContext getTouchContext(int actionIndex)
     {
         if (actionIndex < touchContextMap.length) {
@@ -1887,6 +1918,8 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     public void toggleKeyboard() {
         LimeLog.info("Toggling keyboard overlay");
         InputMethodManager inputManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        streamView.requestFocus();
+        inputManager.restartInput(streamView);
         inputManager.toggleSoftInput(0, 0);
     }
 

--- a/app/src/main/java/com/limelight/GameSbs.java
+++ b/app/src/main/java/com/limelight/GameSbs.java
@@ -74,6 +74,7 @@ import com.limelight.preferences.PreferenceConfiguration;
 import com.limelight.sbs.TextureSurfaceRenderer;
 import com.limelight.sbs.VideoTextureRenderer;
 import com.limelight.ui.GameGestures;
+import com.limelight.ui.StreamInputCallbacks;
 import com.limelight.ui.SBSStreamView;
 import com.limelight.utils.Dialog;
 import com.limelight.utils.ServerHelper;
@@ -91,7 +92,7 @@ import java.util.Locale;
 
 public class GameSbs extends Activity implements TextureView.SurfaceTextureListener,
         OnGenericMotionListener, NvConnectionListener, EvdevListener,
-        OnSystemUiVisibilityChangeListener, GameGestures, SBSStreamView.InputCallbacks, TextureSurfaceRenderer.OnGlReadyListener,
+        OnSystemUiVisibilityChangeListener, GameGestures, StreamInputCallbacks, TextureSurfaceRenderer.OnGlReadyListener,
         PerfOverlayListener, UsbDriverService.UsbDriverStateListener, View.OnKeyListener {
     public static GameSbs instance;
 
@@ -1334,6 +1335,36 @@ public class GameSbs extends Activity implements TextureView.SurfaceTextureListe
         return true;
     }
 
+    @Override
+    public void handleImeText(String text) {
+        if (conn == null || !grabbedInput || text == null || text.isEmpty()) {
+            return;
+        }
+
+        conn.sendUtf8Text(text);
+    }
+
+    @Override
+    public void handleImeBackspace(int count) {
+        sendImeKey((short) KeyboardTranslator.VK_BACK_SPACE, count);
+    }
+
+    @Override
+    public void handleImeForwardDelete(int count) {
+        sendImeKey((short) 0x2e, count);
+    }
+
+    private void sendImeKey(short keyCode, int count) {
+        if (conn == null || !grabbedInput || count <= 0) {
+            return;
+        }
+
+        for (int i = 0; i < count; i++) {
+            conn.sendKeyboardInput(keyCode, KeyboardPacket.KEY_DOWN, getModifierState(), (byte) 0);
+            conn.sendKeyboardInput(keyCode, KeyboardPacket.KEY_UP, getModifierState(), (byte) 0);
+        }
+    }
+
     private TouchContext getTouchContext(int actionIndex) {
         if (actionIndex < touchContextMap.length) {
             return touchContextMap[actionIndex];
@@ -1346,6 +1377,8 @@ public class GameSbs extends Activity implements TextureView.SurfaceTextureListe
     public void toggleKeyboard() {
         LimeLog.info("Toggling keyboard overlay");
         InputMethodManager inputManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        streamView.requestFocus();
+        inputManager.restartInput(streamView);
         inputManager.toggleSoftInput(0, 0);
     }
 

--- a/app/src/main/java/com/limelight/ui/SBSStreamView.java
+++ b/app/src/main/java/com/limelight/ui/SBSStreamView.java
@@ -4,30 +4,55 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.TextureView;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 
 
 public class SBSStreamView extends TextureView {
+   private StreamInputCallbacks inputCallbacks;
+
    public SBSStreamView(Context context) {
       super(context);
+      init();
    }
 
    public SBSStreamView(Context context, AttributeSet attrs) {
       super(context, attrs);
+      init();
    }
 
    public SBSStreamView(Context context, AttributeSet attrs, int defStyleAttr) {
       super(context, attrs, defStyleAttr);
+      init();
    }
 
    private double desiredAspectRatio;
-   private SBSStreamView.InputCallbacks inputCallbacks;
 
    public void setDesiredAspectRatio(double aspectRatio) {
       this.desiredAspectRatio = aspectRatio;
    }
 
-   public void setInputCallbacks(SBSStreamView.InputCallbacks callbacks) {
+   public void setInputCallbacks(StreamInputCallbacks callbacks) {
       this.inputCallbacks = callbacks;
+   }
+
+   private void init() {
+      setFocusable(true);
+      setFocusableInTouchMode(true);
+   }
+
+   @Override
+   public boolean onCheckIsTextEditor() {
+      return true;
+   }
+
+   @Override
+   public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+      outAttrs.inputType = EditorInfo.TYPE_CLASS_TEXT |
+              EditorInfo.TYPE_TEXT_FLAG_AUTO_CORRECT |
+              EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE;
+      outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN;
+      return new StreamImeInputConnection(this, inputCallbacks);
    }
 
    @Override
@@ -73,11 +98,5 @@ public class SBSStreamView extends TextureView {
 
       return super.onKeyPreIme(keyCode, event);
    }
-
-   public interface InputCallbacks {
-      boolean handleKeyUp(KeyEvent event);
-      boolean handleKeyDown(KeyEvent event);
-   }
-
 
 }

--- a/app/src/main/java/com/limelight/ui/StreamImeInputConnection.java
+++ b/app/src/main/java/com/limelight/ui/StreamImeInputConnection.java
@@ -1,0 +1,145 @@
+package com.limelight.ui;
+
+import android.text.Editable;
+import android.text.Selection;
+import android.text.SpannableStringBuilder;
+import android.text.TextUtils;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.BaseInputConnection;
+
+public class StreamImeInputConnection extends BaseInputConnection {
+    private final Editable editable = new SpannableStringBuilder();
+    private final StreamInputCallbacks inputCallbacks;
+    private String composingText = "";
+
+    public StreamImeInputConnection(View targetView, StreamInputCallbacks inputCallbacks) {
+        super(targetView, true);
+        this.inputCallbacks = inputCallbacks;
+        syncEditable();
+    }
+
+    @Override
+    public Editable getEditable() {
+        return editable;
+    }
+
+    @Override
+    public boolean commitText(CharSequence text, int newCursorPosition) {
+        String committedText = text != null ? text.toString() : "";
+
+        if (!TextUtils.isEmpty(committedText)) {
+            replaceRemoteText(composingText, committedText);
+        }
+
+        composingText = "";
+        syncEditable();
+        return true;
+    }
+
+    @Override
+    public boolean setComposingText(CharSequence text, int newCursorPosition) {
+        String newComposingText = text != null ? text.toString() : "";
+        replaceRemoteText(composingText, newComposingText);
+        composingText = newComposingText;
+        syncEditable();
+        return true;
+    }
+
+    @Override
+    public boolean finishComposingText() {
+        composingText = "";
+        syncEditable();
+        return true;
+    }
+
+    @Override
+    public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+        return deleteSurroundingTextInternal(beforeLength, afterLength);
+    }
+
+    @Override
+    public boolean deleteSurroundingTextInCodePoints(int beforeLength, int afterLength) {
+        return deleteSurroundingTextInternal(beforeLength, afterLength);
+    }
+
+    @Override
+    public boolean sendKeyEvent(KeyEvent event) {
+        if (inputCallbacks == null || event == null) {
+            return false;
+        }
+
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            return inputCallbacks.handleKeyDown(event);
+        }
+        else if (event.getAction() == KeyEvent.ACTION_UP) {
+            return inputCallbacks.handleKeyUp(event);
+        }
+
+        return false;
+    }
+
+    private boolean deleteSurroundingTextInternal(int beforeLength, int afterLength) {
+        if (beforeLength > 0 && inputCallbacks != null) {
+            inputCallbacks.handleImeBackspace(beforeLength);
+            composingText = trimTrailingCodePoints(composingText, beforeLength);
+        }
+
+        if (afterLength > 0 && inputCallbacks != null) {
+            inputCallbacks.handleImeForwardDelete(afterLength);
+        }
+
+        syncEditable();
+        return true;
+    }
+
+    private void replaceRemoteText(String oldText, String newText) {
+        if (inputCallbacks == null) {
+            return;
+        }
+
+        int commonPrefixLength = findCommonPrefixLength(oldText, newText);
+        String oldSuffix = oldText.substring(commonPrefixLength);
+        String newSuffix = newText.substring(commonPrefixLength);
+
+        int backspaceCount = codePointCount(oldSuffix);
+        if (backspaceCount > 0) {
+            inputCallbacks.handleImeBackspace(backspaceCount);
+        }
+
+        if (!newSuffix.isEmpty()) {
+            inputCallbacks.handleImeText(newSuffix);
+        }
+    }
+
+    private void syncEditable() {
+        editable.clear();
+        editable.append(composingText);
+        Selection.setSelection(editable, editable.length());
+    }
+
+    private static int findCommonPrefixLength(String first, String second) {
+        int commonPrefixLength = 0;
+        int maxLength = Math.min(first.length(), second.length());
+
+        while (commonPrefixLength < maxLength &&
+                first.charAt(commonPrefixLength) == second.charAt(commonPrefixLength)) {
+            commonPrefixLength++;
+        }
+
+        return commonPrefixLength;
+    }
+
+    private static int codePointCount(String text) {
+        return text.codePointCount(0, text.length());
+    }
+
+    private static String trimTrailingCodePoints(String text, int count) {
+        if (count <= 0 || text.isEmpty()) {
+            return text;
+        }
+
+        int endIndex = text.offsetByCodePoints(text.length(), -Math.min(count, codePointCount(text)));
+        return text.substring(0, endIndex);
+    }
+}

--- a/app/src/main/java/com/limelight/ui/StreamInputCallbacks.java
+++ b/app/src/main/java/com/limelight/ui/StreamInputCallbacks.java
@@ -1,0 +1,11 @@
+package com.limelight.ui;
+
+import android.view.KeyEvent;
+
+public interface StreamInputCallbacks {
+    boolean handleKeyUp(KeyEvent event);
+    boolean handleKeyDown(KeyEvent event);
+    void handleImeText(String text);
+    void handleImeBackspace(int count);
+    void handleImeForwardDelete(int count);
+}

--- a/app/src/main/java/com/limelight/ui/StreamView.java
+++ b/app/src/main/java/com/limelight/ui/StreamView.java
@@ -9,10 +9,12 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.SurfaceView;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 
 public class StreamView extends SurfaceView {
     private double desiredAspectRatio;
-    private InputCallbacks inputCallbacks;
+    private StreamInputCallbacks inputCallbacks;
 
 
     private boolean enableZoomAndPan = false;  // 开关变量，控制缩放和平移功能
@@ -30,7 +32,7 @@ public class StreamView extends SurfaceView {
         this.desiredAspectRatio = aspectRatio;
     }
 
-    public void setInputCallbacks(InputCallbacks callbacks) {
+    public void setInputCallbacks(StreamInputCallbacks callbacks) {
         this.inputCallbacks = callbacks;
     }
 
@@ -55,9 +57,25 @@ public class StreamView extends SurfaceView {
     }
 
     private void init(Context context){
+        setFocusable(true);
+        setFocusableInTouchMode(true);
         // 初始化手势检测器
         gestureDetector = new GestureDetector(context, new GestureListener());
         scaleDetector = new ScaleGestureDetector(context, new ScaleListener());
+    }
+
+    @Override
+    public boolean onCheckIsTextEditor() {
+        return true;
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        outAttrs.inputType = EditorInfo.TYPE_CLASS_TEXT |
+                EditorInfo.TYPE_TEXT_FLAG_AUTO_CORRECT |
+                EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE;
+        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN;
+        return new StreamImeInputConnection(this, inputCallbacks);
     }
 
     @Override
@@ -102,11 +120,6 @@ public class StreamView extends SurfaceView {
         }
 
         return super.onKeyPreIme(keyCode, event);
-    }
-
-    public interface InputCallbacks {
-        boolean handleKeyUp(KeyEvent event);
-        boolean handleKeyDown(KeyEvent event);
     }
 
     public void setEnableZoomAndPan(boolean enableZoomAndPan) {


### PR DESCRIPTION
## Summary
Software keyboards such as Sogou can keep composing text locally. Without a real InputConnection, deleting characters may only clear the IME's local composing buffer first, and backspace is not sent to the remote host until several presses later.

This change adds a minimal InputConnection for the stream views, synchronizes composing text to the host, and forwards delete/backspace operations immediately.

## Result
Soft-keyboard input behaves more naturally, especially when editing previously composed text.