### PR TITLE
feat: 添加软键盘扩展、@ 输入兼容与 Ubuntu 26.04 开发镜像

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -26,6 +26,12 @@ import com.limelight.binding.video.PerfOverlayListener;
 import com.limelight.binding.video.PerfOverlayStats;
 import com.limelight.fsr.FsrVideoProcessor;
 import com.limelight.fsr.VideoProcessingGLSurfaceView;
+// EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+import com.limelight.extensions.keyboard.ImeKeyboardExtensionController;
+// EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
+// EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [MODIFIED] BEGIN
+import com.limelight.extensions.keyboard.ImeTextInputCompatibilityExtension;
+// EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [MODIFIED] END
 import com.limelight.stereo3d.Stereo3dOutputLayout;
 import com.limelight.nvstream.MicUplinkConnection;
 import com.limelight.nvstream.NvConnection;
@@ -205,6 +211,10 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     private KeyBoardController keyBoardController;
 
     private KeyBoardLayoutController keyBoardLayoutController;
+
+    // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+    private ImeKeyboardExtensionController imeKeyboardExtensionController;
+    // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
 
     public PreferenceConfiguration prefConfig;
     private SharedPreferences tombstonePrefs;
@@ -933,6 +943,13 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         InputManager inputManager = (InputManager) getSystemService(Context.INPUT_SERVICE);
         inputManager.registerInputDeviceListener(keyboardTranslator, null);
 
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+        imeKeyboardExtensionController = new ImeKeyboardExtensionController(
+                this,
+                (FrameLayout) rootView,
+                (keyCode, down) -> keyboardEvent(down, (short) keyCode));
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
+
         // Initialize touch contexts
 //        for (int i = 0; i < touchContextMap.length; i++) {
 //            if (!prefConfig.touchscreenTrackpad) {
@@ -1323,6 +1340,12 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
 
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+        if (!hasFocus && imeKeyboardExtensionController != null) {
+            imeKeyboardExtensionController.releasePressedKeys();
+        }
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
+
         // We can't guarantee the state of modifiers keys which may have
         // lifted while focus was not on us. Clear the modifier state.
         this.modifierFlags = 0;
@@ -1637,6 +1660,13 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         logSessionInfo("LIFECYCLE", "串流页面正在销毁");
         backgroundReconnectHandler.removeCallbacksAndMessages(null);
         releaseExternalDisplayRouting();
+
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+        if (imeKeyboardExtensionController != null) {
+            imeKeyboardExtensionController.destroy();
+            imeKeyboardExtensionController = null;
+        }
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
 
         if (virtualMouseOverlay != null) {
             virtualMouseOverlay.destroy();
@@ -2022,6 +2052,29 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         return (byte) modifierFlags;
     }
 
+    // EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [MODIFIED] BEGIN
+    private void sendImeCommittedText(String text) {
+        boolean dispatchedAsKeyStroke = ImeTextInputCompatibilityExtension.dispatchIfCompatible(
+                text,
+                this::dispatchImeCompatibilityKeyStroke);
+        if (!dispatchedAsKeyStroke) {
+            conn.sendUtf8Text(text);
+        }
+    }
+
+    private boolean dispatchImeCompatibilityKeyStroke(int androidKeyCode, byte requiredModifiers) {
+        short keyMap = keyboardTranslator.translate(androidKeyCode, -1);
+        if (keyMap == 0) {
+            return false;
+        }
+
+        byte modifiers = (byte) (getModifierState() | requiredModifiers);
+        conn.sendKeyboardInput(keyMap, KeyboardPacket.KEY_DOWN, modifiers, (byte) 0);
+        conn.sendKeyboardInput(keyMap, KeyboardPacket.KEY_UP, modifiers, (byte) 0);
+        return true;
+    }
+    // EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [MODIFIED] END
+
     private boolean isPhysicalKeyboardEscapeMenuEvent(KeyEvent event) {
         if (!prefConfig.keyboardEscOpensGameMenu || !connected
                 || event.getKeyCode() != KeyEvent.KEYCODE_ESCAPE
@@ -2118,7 +2171,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 // UTF-8 events don't auto-repeat on the host side.
                 int unicodeChar = event.getUnicodeChar();
                 if ((unicodeChar & KeyCharacterMap.COMBINING_ACCENT) == 0 && (unicodeChar & KeyCharacterMap.COMBINING_ACCENT_MASK) != 0) {
-                    conn.sendUtf8Text(""+(char)unicodeChar);
+                    // EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [MODIFIED] BEGIN
+                    sendImeCommittedText(""+(char)unicodeChar);
+                    // EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [MODIFIED] END
                     return true;
                 }
 
@@ -2227,7 +2282,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             return false;
         }
 
-        conn.sendUtf8Text(event.getCharacters());
+        // EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [MODIFIED] BEGIN
+        sendImeCommittedText(event.getCharacters());
+        // EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [MODIFIED] END
         return true;
     }
 

--- a/app/src/main/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionController.java
+++ b/app/src/main/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionController.java
@@ -1,0 +1,255 @@
+package com.limelight.extensions.keyboard;
+
+import android.app.Activity;
+import android.graphics.Rect;
+import android.os.Build;
+import android.util.SparseArray;
+import android.util.SparseBooleanArray;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.view.WindowInsets;
+import android.view.WindowManager;
+import android.widget.FrameLayout;
+
+import com.limelight.R;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+ *
+ * <p>Adds PC shortcut keys immediately above a docked Android IME.</p>
+ *
+ * <p>This controller is intentionally self-contained. It mounts its own view at runtime,
+ * observes IME visibility without changing the stream layout, and reports Android key codes
+ * through a small callback so the existing input pipeline remains untouched.</p>
+ */
+public final class ImeKeyboardExtensionController {
+    public interface KeyDispatcher {
+        void dispatchKey(int keyCode, boolean down);
+    }
+
+    private static final int MIN_DOCKED_IME_HEIGHT_DP = 100;
+
+    private final Activity activity;
+    private final FrameLayout host;
+    private final KeyDispatcher keyDispatcher;
+    private final View keyboardBar;
+    private final Rect visibleDisplayFrame = new Rect();
+    private final SparseArray<View> momentaryKeyViews = new SparseArray<>();
+    private final SparseBooleanArray momentaryKeyStates = new SparseBooleanArray();
+    private final int minimumDockedImeHeightPx;
+    private final int originalSoftInputMode;
+
+    private final SparseArray<View> latchedKeyViews = new SparseArray<>();
+    private final SparseBooleanArray latchedKeyStates = new SparseBooleanArray();
+    private boolean destroyed;
+    private boolean lastVisible;
+    private int lastBottomMargin = Integer.MIN_VALUE;
+
+    private final ViewTreeObserver.OnGlobalLayoutListener globalLayoutListener =
+            this::updateKeyboardBarPosition;
+
+    public ImeKeyboardExtensionController(Activity activity, FrameLayout host,
+                                          KeyDispatcher keyDispatcher) {
+        this.activity = activity;
+        this.host = host;
+        this.keyDispatcher = keyDispatcher;
+        this.minimumDockedImeHeightPx = Math.round(
+                MIN_DOCKED_IME_HEIGHT_DP * activity.getResources().getDisplayMetrics().density);
+        this.originalSoftInputMode = activity.getWindow().getAttributes().softInputMode;
+
+        keyboardBar = LayoutInflater.from(activity).inflate(
+                R.layout.extension_ime_keyboard_bar, host, false);
+        FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        layoutParams.gravity = Gravity.BOTTOM;
+        keyboardBar.setLayoutParams(layoutParams);
+        keyboardBar.setVisibility(View.GONE);
+
+        bindMomentaryKey(R.id.extension_key_escape, KeyEvent.KEYCODE_ESCAPE);
+        bindMomentaryKey(R.id.extension_key_tab, KeyEvent.KEYCODE_TAB);
+        bindMomentaryKey(R.id.extension_key_unknown, KeyEvent.KEYCODE_UNKNOWN);
+        bindMomentaryKey(R.id.extension_key_home, KeyEvent.KEYCODE_MOVE_HOME);
+        bindMomentaryKey(R.id.extension_key_up, KeyEvent.KEYCODE_DPAD_UP);
+        bindMomentaryKey(R.id.extension_key_end, KeyEvent.KEYCODE_MOVE_END);
+        bindMomentaryKey(R.id.extension_key_page_up, KeyEvent.KEYCODE_PAGE_UP);
+
+        bindLatchedKey(R.id.extension_key_cmd, KeyEvent.KEYCODE_META_LEFT);
+        bindLatchedKey(R.id.extension_key_ctrl, KeyEvent.KEYCODE_CTRL_LEFT);
+        bindLatchedKey(R.id.extension_key_alt, KeyEvent.KEYCODE_ALT_LEFT);
+        bindMomentaryKey(R.id.extension_key_left, KeyEvent.KEYCODE_DPAD_LEFT);
+        bindMomentaryKey(R.id.extension_key_down, KeyEvent.KEYCODE_DPAD_DOWN);
+        bindMomentaryKey(R.id.extension_key_right, KeyEvent.KEYCODE_DPAD_RIGHT);
+        bindMomentaryKey(R.id.extension_key_page_down, KeyEvent.KEYCODE_PAGE_DOWN);
+
+        host.addView(keyboardBar);
+        host.getViewTreeObserver().addOnGlobalLayoutListener(globalLayoutListener);
+
+        int resizeSoftInputMode = (originalSoftInputMode
+                & ~WindowManager.LayoutParams.SOFT_INPUT_MASK_ADJUST)
+                | WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE;
+        activity.getWindow().setSoftInputMode(resizeSoftInputMode);
+
+        host.post(this::updateKeyboardBarPosition);
+    }
+
+    private void bindMomentaryKey(int viewId, int keyCode) {
+        View keyView = keyboardBar.findViewById(viewId);
+        momentaryKeyViews.put(keyCode, keyView);
+        keyView.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View view, MotionEvent event) {
+                switch (event.getActionMasked()) {
+                    case MotionEvent.ACTION_DOWN:
+                        if (!momentaryKeyStates.get(keyCode)) {
+                            momentaryKeyStates.put(keyCode, true);
+                            view.setSelected(true);
+                            keyDispatcher.dispatchKey(keyCode, true);
+                        }
+                        return true;
+
+                    case MotionEvent.ACTION_UP:
+                        if (momentaryKeyStates.get(keyCode)) {
+                            momentaryKeyStates.delete(keyCode);
+                            view.setSelected(false);
+                            keyDispatcher.dispatchKey(keyCode, false);
+                        }
+                        view.performClick();
+                        return true;
+
+                    case MotionEvent.ACTION_CANCEL:
+                        if (momentaryKeyStates.get(keyCode)) {
+                            momentaryKeyStates.delete(keyCode);
+                            view.setSelected(false);
+                            keyDispatcher.dispatchKey(keyCode, false);
+                        }
+                        return true;
+
+                    default:
+                        return true;
+                }
+            }
+        });
+    }
+
+    private void bindLatchedKey(int viewId, int keyCode) {
+        View keyView = keyboardBar.findViewById(viewId);
+        latchedKeyViews.put(keyCode, keyView);
+        keyView.setOnClickListener(view -> {
+            boolean latched = !latchedKeyStates.get(keyCode);
+            if (latched) {
+                latchedKeyStates.put(keyCode, true);
+            }
+            else {
+                latchedKeyStates.delete(keyCode);
+            }
+
+            view.setSelected(latched);
+            keyDispatcher.dispatchKey(keyCode, latched);
+        });
+    }
+
+    private void updateKeyboardBarPosition() {
+        if (destroyed || !host.isAttachedToWindow()) {
+            return;
+        }
+
+        View decorView = activity.getWindow().getDecorView();
+        decorView.getWindowVisibleDisplayFrame(visibleDisplayFrame);
+
+        int[] decorLocation = new int[2];
+        int[] hostLocation = new int[2];
+        decorView.getLocationOnScreen(decorLocation);
+        host.getLocationOnScreen(hostLocation);
+
+        int decorBottom = decorLocation[1] + decorView.getHeight();
+        int hostBottom = hostLocation[1] + host.getHeight();
+        int keyboardTop = visibleDisplayFrame.bottom;
+        int obscuredHeight = Math.max(0, decorBottom - keyboardTop);
+
+        boolean imeVisible = obscuredHeight >= minimumDockedImeHeightPx;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsets insets = host.getRootWindowInsets();
+            if (insets != null) {
+                int imeHeight = insets.getInsets(WindowInsets.Type.ime()).bottom;
+                // A floating or split IME does not expose a usable bottom edge. In that case,
+                // leave this docked accessory hidden instead of placing it at the wrong edge.
+                imeVisible = insets.isVisible(WindowInsets.Type.ime())
+                        && imeHeight >= minimumDockedImeHeightPx;
+                if (imeVisible) {
+                    // WindowMetrics retains the full activity bounds even when adjustResize has
+                    // already shortened the content view. This avoids applying the IME height
+                    // twice on devices that honor adjustResize in fullscreen mode.
+                    Rect windowBounds = activity.getWindowManager()
+                            .getCurrentWindowMetrics().getBounds();
+                    keyboardTop = windowBounds.bottom - imeHeight;
+                }
+            }
+        }
+
+        int bottomMargin = imeVisible ? Math.max(0, hostBottom - keyboardTop) : 0;
+        applyVisibilityAndMargin(imeVisible, bottomMargin);
+    }
+
+    private void applyVisibilityAndMargin(boolean visible, int bottomMargin) {
+        if (visible != lastVisible) {
+            lastVisible = visible;
+            keyboardBar.setVisibility(visible ? View.VISIBLE : View.GONE);
+            if (!visible) {
+                releasePressedKeys();
+            }
+        }
+
+        if (visible && bottomMargin != lastBottomMargin) {
+            lastBottomMargin = bottomMargin;
+            FrameLayout.LayoutParams layoutParams =
+                    (FrameLayout.LayoutParams) keyboardBar.getLayoutParams();
+            layoutParams.bottomMargin = bottomMargin;
+            keyboardBar.setLayoutParams(layoutParams);
+        }
+    }
+
+    private void releaseLatchedModifiers() {
+        for (int index = latchedKeyStates.size() - 1; index >= 0; index--) {
+            int keyCode = latchedKeyStates.keyAt(index);
+            View keyView = latchedKeyViews.get(keyCode);
+            if (keyView != null) {
+                keyView.setSelected(false);
+            }
+            keyDispatcher.dispatchKey(keyCode, false);
+        }
+        latchedKeyStates.clear();
+    }
+
+    public void releasePressedKeys() {
+        for (int index = momentaryKeyStates.size() - 1; index >= 0; index--) {
+            int keyCode = momentaryKeyStates.keyAt(index);
+            View keyView = momentaryKeyViews.get(keyCode);
+            if (keyView != null) {
+                keyView.setSelected(false);
+            }
+            keyDispatcher.dispatchKey(keyCode, false);
+        }
+        momentaryKeyStates.clear();
+        releaseLatchedModifiers();
+    }
+
+    public void destroy() {
+        if (destroyed) {
+            return;
+        }
+        destroyed = true;
+
+        releasePressedKeys();
+        ViewTreeObserver observer = host.getViewTreeObserver();
+        if (observer.isAlive()) {
+            observer.removeOnGlobalLayoutListener(globalLayoutListener);
+        }
+        host.removeView(keyboardBar);
+        activity.getWindow().setSoftInputMode(originalSoftInputMode);
+    }
+}

--- a/app/src/main/java/com/limelight/extensions/keyboard/ImeTextInputCompatibilityExtension.java
+++ b/app/src/main/java/com/limelight/extensions/keyboard/ImeTextInputCompatibilityExtension.java
@@ -1,0 +1,43 @@
+package com.limelight.extensions.keyboard;
+
+import android.view.KeyEvent;
+
+import com.limelight.nvstream.input.KeyboardPacket;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [ADDED]
+ *
+ * <p>Provides client-side compatibility mappings for text committed by an Android IME.</p>
+ *
+ * <p>Sunshine on Linux currently injects UTF-8 text through the Ctrl+Shift+U Unicode input
+ * sequence. Some applications do not support that sequence, so an {@code @} received as UTF-8
+ * can leave a visible "U+" composition instead of entering the character. Keep this workaround
+ * isolated so it is easy to identify, review, or remove when Sunshine issue #5274 is resolved.</p>
+ *
+ * <p>The mapping below assumes a US/QWERTY host layout, matching Moonlight's normalized keyboard
+ * protocol mapping: {@code @} is emitted as Shift+2. Other text continues through the existing
+ * UTF-8 path unchanged.</p>
+ */
+public final class ImeTextInputCompatibilityExtension {
+    public interface KeyStrokeDispatcher {
+        boolean dispatchKeyStroke(int androidKeyCode, byte requiredModifiers);
+    }
+
+    private ImeTextInputCompatibilityExtension() {
+    }
+
+    /**
+     * Attempts to replace a known-problematic single-character IME text commit with a key stroke.
+     *
+     * @return {@code true} only when the text was successfully dispatched as a key stroke
+     */
+    public static boolean dispatchIfCompatible(String text, KeyStrokeDispatcher dispatcher) {
+        if (!"@".equals(text)) {
+            return false;
+        }
+
+        return dispatcher.dispatchKeyStroke(
+                KeyEvent.KEYCODE_2,
+                KeyboardPacket.MODIFIER_SHIFT);
+    }
+}

--- a/app/src/main/res/drawable/extension_ime_keyboard_key.xml
+++ b/app/src/main/res/drawable/extension_ime_keyboard_key.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+  Pressed and latched states for IME extension keys.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape>
+            <solid android:color="#7C3AED" />
+            <stroke android:width="1dp" android:color="#C4B5FD" />
+            <corners android:radius="5dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="#5B21B6" />
+            <stroke android:width="1dp" android:color="#A78BFA" />
+            <corners android:radius="5dp" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="#383838" />
+            <stroke android:width="1dp" android:color="#5A5A5A" />
+            <corners android:radius="5dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/extension_ime_keyboard_bar.xml
+++ b/app/src/main/res/layout/extension_ime_keyboard_bar.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+  Two-row PC shortcut bar displayed above a docked system IME.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#F2212121"
+    android:clickable="true"
+    android:elevation="8dp"
+    android:focusable="false"
+    android:orientation="vertical"
+    android:padding="3dp"
+    tools:ignore="KeyboardInaccessibleWidget,Overdraw">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="38dp"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:weightSum="7">
+
+        <TextView
+            android:id="@+id/extension_key_escape"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_escape" />
+
+        <TextView
+            android:id="@+id/extension_key_tab"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_tab" />
+
+        <TextView
+            android:id="@+id/extension_key_unknown"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_unknown" />
+
+        <TextView
+            android:id="@+id/extension_key_home"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_home" />
+
+        <TextView
+            android:id="@+id/extension_key_up"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_up_description"
+            android:text="@string/extension_ime_key_up" />
+
+        <TextView
+            android:id="@+id/extension_key_end"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_end" />
+
+        <TextView
+            android:id="@+id/extension_key_page_up"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_page_up" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="38dp"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:weightSum="7">
+
+        <TextView
+            android:id="@+id/extension_key_cmd"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_cmd_description"
+            android:text="@string/extension_ime_key_cmd" />
+
+        <TextView
+            android:id="@+id/extension_key_ctrl"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_ctrl_description"
+            android:text="@string/extension_ime_key_ctrl" />
+
+        <TextView
+            android:id="@+id/extension_key_alt"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_alt_description"
+            android:text="@string/extension_ime_key_alt" />
+
+        <TextView
+            android:id="@+id/extension_key_left"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_left_description"
+            android:text="@string/extension_ime_key_left" />
+
+        <TextView
+            android:id="@+id/extension_key_down"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_down_description"
+            android:text="@string/extension_ime_key_down" />
+
+        <TextView
+            android:id="@+id/extension_key_right"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_right_description"
+            android:text="@string/extension_ime_key_right" />
+
+        <TextView
+            android:id="@+id/extension_key_page_down"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_page_down" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/extension_ime_keyboard_styles.xml
+++ b/app/src/main/res/values/extension_ime_keyboard_styles.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+  Resources owned by the docked IME shortcut-bar extension.
+-->
+<resources>
+    <string name="extension_ime_key_escape" translatable="false">ESC</string>
+    <string name="extension_ime_key_unknown" translatable="false">Unknown</string>
+    <string name="extension_ime_key_home" translatable="false">HOME</string>
+    <string name="extension_ime_key_up" translatable="false">↑</string>
+    <string name="extension_ime_key_up_description" translatable="false">UP</string>
+    <string name="extension_ime_key_end" translatable="false">END</string>
+    <string name="extension_ime_key_page_up" translatable="false">PGUP</string>
+    <string name="extension_ime_key_tab" translatable="false">TAB</string>
+    <string name="extension_ime_key_cmd" translatable="false">CMD</string>
+    <string name="extension_ime_key_cmd_description" translatable="false">CMD，可锁定</string>
+    <string name="extension_ime_key_ctrl" translatable="false">CTRL</string>
+    <string name="extension_ime_key_ctrl_description" translatable="false">CTRL，可锁定</string>
+    <string name="extension_ime_key_alt" translatable="false">ALT</string>
+    <string name="extension_ime_key_alt_description" translatable="false">ALT，可锁定</string>
+    <string name="extension_ime_key_left" translatable="false">←</string>
+    <string name="extension_ime_key_left_description" translatable="false">LEFT</string>
+    <string name="extension_ime_key_down" translatable="false">↓</string>
+    <string name="extension_ime_key_down_description" translatable="false">DOWN</string>
+    <string name="extension_ime_key_right" translatable="false">→</string>
+    <string name="extension_ime_key_right_description" translatable="false">RIGHT</string>
+    <string name="extension_ime_key_page_down" translatable="false">PGDN</string>
+
+    <style name="ImeKeyboardExtensionKey">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">match_parent</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:layout_margin">2dp</item>
+        <item name="android:background">@drawable/extension_ime_keyboard_key</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">false</item>
+        <item name="android:gravity">center</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textSize">11sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+</resources>

--- a/app/src/test/java/com/limelight/extensions/keyboard/ImeTextInputCompatibilityExtensionTest.java
+++ b/app/src/test/java/com/limelight/extensions/keyboard/ImeTextInputCompatibilityExtensionTest.java
@@ -1,0 +1,76 @@
+package com.limelight.extensions.keyboard;
+
+import android.view.KeyEvent;
+
+import com.limelight.nvstream.input.KeyboardPacket;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-AT-SIGN] [ADDED]
+ * Coverage for the Sunshine/Linux IME '@' compatibility mapping.
+ */
+public class ImeTextInputCompatibilityExtensionTest {
+    @Test
+    public void atSignDispatchesAsShiftTwo() {
+        AtomicInteger dispatchedKeyCode = new AtomicInteger(KeyEvent.KEYCODE_UNKNOWN);
+        AtomicInteger dispatchedModifiers = new AtomicInteger();
+
+        boolean handled = ImeTextInputCompatibilityExtension.dispatchIfCompatible(
+                "@",
+                (keyCode, modifiers) -> {
+                    dispatchedKeyCode.set(keyCode);
+                    dispatchedModifiers.set(modifiers);
+                    return true;
+                });
+
+        assertTrue(handled);
+        assertEquals(KeyEvent.KEYCODE_2, dispatchedKeyCode.get());
+        assertEquals(KeyboardPacket.MODIFIER_SHIFT, dispatchedModifiers.get());
+    }
+
+    @Test
+    public void unrelatedTextRemainsOnExistingUtf8Path() {
+        AtomicInteger dispatchCount = new AtomicInteger();
+
+        boolean handled = ImeTextInputCompatibilityExtension.dispatchIfCompatible(
+                "example",
+                (keyCode, modifiers) -> {
+                    dispatchCount.incrementAndGet();
+                    return true;
+                });
+
+        assertFalse(handled);
+        assertEquals(0, dispatchCount.get());
+    }
+
+    @Test
+    public void atSignFallsBackWhenKeyStrokeCannotBeDispatched() {
+        boolean handled = ImeTextInputCompatibilityExtension.dispatchIfCompatible(
+                "@",
+                (keyCode, modifiers) -> false);
+
+        assertFalse(handled);
+    }
+
+    @Test
+    public void multiCharacterCommitIsNotPartiallyRewritten() {
+        AtomicInteger dispatchCount = new AtomicInteger();
+
+        boolean handled = ImeTextInputCompatibilityExtension.dispatchIfCompatible(
+                "name@example.com",
+                (keyCode, modifiers) -> {
+                    dispatchCount.incrementAndGet();
+                    return true;
+                });
+
+        assertFalse(handled);
+        assertEquals(0, dispatchCount.get());
+    }
+}

--- a/dev/docker/android/Dockerfile
+++ b/dev/docker/android/Dockerfile
@@ -1,0 +1,121 @@
+FROM ubuntu:26.04@sha256:7c274af287d8f66f861d90e6ceab5cc27349b8db1fea54d44fc2bb6442210c8b
+
+LABEL org.opencontainers.image.title="Moonlight Android development environment" \
+      org.opencontainers.image.description="Pinned Android SDK/NDK toolchain for moonlight-android-keyboard" \
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:26.04"
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG DEV_UID=1000
+ARG DEV_GID=1000
+ARG ANDROID_CMDLINE_TOOLS_VERSION=16111833
+ARG ANDROID_CMDLINE_TOOLS_SHA256=0877a1d048fe4a24efe2eff536ca4223f7adeb58648bb81909d33c446918cfa8
+
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 \
+    ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk \
+    ANDROID_COMPILE_SDK=34 \
+    ANDROID_BUILD_TOOLS_VERSION=34.0.0 \
+    ANDROID_NDK_VERSION=27.0.12077973 \
+    ANDROID_NDK_HOME=/opt/android-sdk/ndk/27.0.12077973 \
+    ANDROID_NDK_ROOT=/opt/android-sdk/ndk/27.0.12077973 \
+    NDK_HOME=/opt/android-sdk/ndk/27.0.12077973 \
+    GRADLE_VERSION=8.7 \
+    ANDROID_GRADLE_PLUGIN_VERSION=8.5.1 \
+    ANDROID_CMDLINE_TOOLS_VERSION=${ANDROID_CMDLINE_TOOLS_VERSION}
+
+ENV PATH=${JAVA_HOME}/bin:${ANDROID_SDK_ROOT}/cmdline-tools/${ANDROID_CMDLINE_TOOLS_VERSION}/bin:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}:${ANDROID_NDK_HOME}:${PATH}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        file \
+        git \
+        make \
+        openjdk-17-jdk-headless \
+        openssh-client \
+        unzip \
+        xz-utils \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN test "$(dpkg --print-architecture)" = "amd64" \
+    && mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools" \
+    && curl --fail --location --show-error --silent \
+        --retry 5 --retry-delay 2 \
+        --output /tmp/android-commandlinetools.zip \
+        "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_CMDLINE_TOOLS_VERSION}_latest.zip" \
+    && echo "${ANDROID_CMDLINE_TOOLS_SHA256}  /tmp/android-commandlinetools.zip" | sha256sum --check --strict \
+    && unzip -q /tmp/android-commandlinetools.zip -d /tmp/android-commandlinetools \
+    && mv /tmp/android-commandlinetools/cmdline-tools "${ANDROID_SDK_ROOT}/cmdline-tools/${ANDROID_CMDLINE_TOOLS_VERSION}" \
+    && ln -s "${ANDROID_CMDLINE_TOOLS_VERSION}" "${ANDROID_SDK_ROOT}/cmdline-tools/latest" \
+    && rm -rf /tmp/android-commandlinetools /tmp/android-commandlinetools.zip
+
+RUN set +o pipefail \
+    && yes | sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null \
+    && license_status=${PIPESTATUS[1]} \
+    && set -o pipefail \
+    && test "${license_status}" -eq 0 \
+    && sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --install \
+        "platform-tools" \
+        "platforms;android-${ANDROID_COMPILE_SDK}" \
+        "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+        "ndk;${ANDROID_NDK_VERSION}" \
+    && rm -rf /root/.android/cache /root/.android/repositories.cfg /tmp/*
+
+# The current Android CLI installs some host executables with owner-only mode.
+# The SDK is immutable at runtime, but every development user must be able to
+# read it and execute its tools.
+RUN chmod -R a+rX "${ANDROID_SDK_ROOT}"
+
+ARG GRADLE_DIST_SHA256=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
+RUN curl --fail --location --show-error --silent \
+        --retry 5 --retry-delay 2 \
+        --output /tmp/gradle-bin.zip \
+        "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+    && echo "${GRADLE_DIST_SHA256}  /tmp/gradle-bin.zip" | sha256sum --check --strict \
+    && mkdir -p /opt/gradle \
+    && unzip -q /tmp/gradle-bin.zip -d /opt/gradle \
+    && rm -f /tmp/gradle-bin.zip \
+    && chmod -R a+rX /opt/gradle
+
+ENV GRADLE_HOME=/opt/gradle/gradle-${GRADLE_VERSION}
+ENV PATH=${GRADLE_HOME}/bin:${PATH}
+
+RUN existing_user="$(getent passwd "${DEV_UID}" | cut -d: -f1 || true)" \
+    && existing_group="$(getent group "${DEV_GID}" | cut -d: -f1 || true)" \
+    && if [[ -n "${existing_user}" ]]; then \
+           usermod --login developer --home /home/developer --move-home "${existing_user}"; \
+       fi \
+    && if [[ -n "${existing_group}" ]]; then \
+           groupmod --new-name developer "${existing_group}"; \
+       else \
+           groupadd --gid "${DEV_GID}" developer; \
+       fi \
+    && if [[ -z "${existing_user}" ]]; then \
+           useradd --uid "${DEV_UID}" --gid "${DEV_GID}" \
+               --create-home --shell /bin/bash developer; \
+       else \
+           usermod --gid "${DEV_GID}" developer; \
+       fi \
+    && usermod --groups "" developer \
+    && mkdir -p /workspace /home/developer/.android /home/developer/.gradle \
+    && chown -R "${DEV_UID}:${DEV_GID}" \
+        /workspace /home/developer/.android /home/developer/.gradle
+
+COPY verify-environment.sh /usr/local/bin/verify-android-environment
+RUN chmod 0755 /usr/local/bin/verify-android-environment
+
+USER developer
+ENV HOME=/home/developer \
+    GRADLE_USER_HOME=/home/developer/.gradle
+WORKDIR /workspace
+
+RUN verify-android-environment
+
+CMD ["/bin/bash"]

--- a/dev/docker/android/README.md
+++ b/dev/docker/android/README.md
@@ -1,0 +1,87 @@
+# Android development image
+
+This image contains the Linux toolchain required by the current project. The
+versions come from the checked-in Gradle configuration rather than floating
+`latest` packages:
+
+- Ubuntu 26.04 (official image, pinned by digest)
+- OpenJDK 17 runtime for Android Gradle Plugin 8.5.1
+- Gradle 8.7, pinned by the official distribution checksum
+- Android SDK Platform 34 and Build Tools 34.0.0
+- Android NDK 27.0.12077973
+- Android Platform Tools for `adb`
+- Git, Make, ZIP and host utilities needed by the wrapper and `ndk-build`
+
+The Android Command-line Tools archive is pinned to build `16111833`. It and
+the Gradle 8.7 distribution are verified with SHA-256 during the image build.
+The image intentionally does not copy the source tree or pre-download Maven
+dependencies.
+
+## Build
+
+Run this from the repository root:
+
+```bash
+docker build \
+  --network host \
+  --build-arg DEV_UID="$(id -u)" \
+  --build-arg DEV_GID="$(id -g)" \
+  --tag moonlight-android-dev:ubuntu-26.04 \
+  --file dev/docker/android/Dockerfile \
+  dev/docker/android
+```
+
+The UID and GID arguments ensure that Gradle outputs written to the mounted
+source tree belong to the host user.
+
+If the host uses an HTTP proxy, add these predefined Docker build arguments;
+Docker excludes their values from the resulting image history:
+
+```bash
+--build-arg HTTP_PROXY --build-arg HTTPS_PROXY --build-arg NO_PROXY
+```
+
+## Run
+
+Initialize the native submodule once on the host:
+
+```bash
+git submodule update --init --recursive
+```
+
+Start a development shell:
+
+```bash
+docker run --rm -it \
+  --network host \
+  --volume "$PWD:/workspace" \
+  --volume "${HOME}/.gradle:/home/developer/.gradle" \
+  moonlight-android-dev:ubuntu-26.04
+```
+
+The image sets `ANDROID_HOME`, `ANDROID_SDK_ROOT`, `ANDROID_NDK_HOME`,
+`ANDROID_NDK_ROOT`, `NDK_HOME`, `JAVA_HOME`, and the required `PATH`. A
+`local.properties` file is not needed for command-line builds in the container.
+
+Verify that the mounted project still matches the image:
+
+```bash
+verify-android-environment /workspace
+```
+
+Build and run the unit tests with the preinstalled Gradle 8.7:
+
+```bash
+gradle --no-daemon \
+  testNonRootDebugUnitTest \
+  :optional-stereo3d-api:test \
+  assembleNonRootDebug
+```
+
+The checked-in `./gradlew` remains authoritative and is verified to reference
+the same Gradle 8.7 version. It can also be used when its distribution is
+already cached or network access to `services.gradle.org` is available.
+
+For a USB-connected Android device, pass only the required USB device or bus
+to `docker run`, then use the included `adb`. Network ADB works directly with
+the documented `--network host` mode.

--- a/dev/docker/android/verify-environment.sh
+++ b/dev/docker/android/verify-environment.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+require_file() {
+    [[ -f "$1" ]] || fail "required file is missing: $1"
+}
+
+require_command() {
+    local command_path
+    command_path="$(command -v "$1")" || fail "required command is missing: $1"
+    [[ -x "${command_path}" ]] || fail "required command is not executable: ${command_path}"
+}
+
+: "${ANDROID_SDK_ROOT:?ANDROID_SDK_ROOT is not set}"
+: "${ANDROID_COMPILE_SDK:?ANDROID_COMPILE_SDK is not set}"
+: "${ANDROID_BUILD_TOOLS_VERSION:?ANDROID_BUILD_TOOLS_VERSION is not set}"
+: "${ANDROID_NDK_VERSION:?ANDROID_NDK_VERSION is not set}"
+: "${ANDROID_CMDLINE_TOOLS_VERSION:?ANDROID_CMDLINE_TOOLS_VERSION is not set}"
+: "${GRADLE_VERSION:?GRADLE_VERSION is not set}"
+: "${ANDROID_GRADLE_PLUGIN_VERSION:?ANDROID_GRADLE_PLUGIN_VERSION is not set}"
+
+for tool in java javac gradle sdkmanager adb ndk-build make git; do
+    require_command "${tool}"
+done
+
+java_major="$(java -version 2>&1 | sed -n '1s/.*version "\([0-9][0-9]*\).*/\1/p')"
+[[ "${java_major}" == "17" ]] || fail "expected JDK 17, found: $(java -version 2>&1 | head -n 1)"
+
+gradle_version="$(gradle --version | sed -n 's/^Gradle //p')"
+[[ "${gradle_version}" == "${GRADLE_VERSION}" ]] \
+    || fail "expected Gradle ${GRADLE_VERSION}, found ${gradle_version:-unknown}"
+
+require_file "${ANDROID_SDK_ROOT}/cmdline-tools/${ANDROID_CMDLINE_TOOLS_VERSION}/source.properties"
+require_file "${ANDROID_SDK_ROOT}/platforms/android-${ANDROID_COMPILE_SDK}/package.xml"
+require_file "${ANDROID_SDK_ROOT}/build-tools/${ANDROID_BUILD_TOOLS_VERSION}/package.xml"
+require_file "${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}/source.properties"
+
+ndk_revision="$(sed -n 's/^Pkg.Revision[[:space:]]*=[[:space:]]*//p' \
+    "${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}/source.properties")"
+[[ "${ndk_revision}" == "${ANDROID_NDK_VERSION}" ]] \
+    || fail "expected NDK ${ANDROID_NDK_VERSION}, found ${ndk_revision:-unknown}"
+
+project_dir="${1:-}"
+if [[ -n "${project_dir}" ]]; then
+    project_dir="$(cd "${project_dir}" && pwd)"
+    require_file "${project_dir}/app/build.gradle"
+    require_file "${project_dir}/build.gradle"
+    require_file "${project_dir}/gradle/wrapper/gradle-wrapper.properties"
+
+    grep -Eq "ndkVersion[[:space:]]+['\"]${ANDROID_NDK_VERSION}['\"]" \
+        "${project_dir}/app/build.gradle" \
+        || fail "project NDK version differs from ${ANDROID_NDK_VERSION}"
+    grep -Eq "compileSdk[[:space:]]+${ANDROID_COMPILE_SDK}([^0-9]|$)" \
+        "${project_dir}/app/build.gradle" \
+        || fail "project compileSdk differs from ${ANDROID_COMPILE_SDK}"
+    grep -Fq "com.android.tools.build:gradle:${ANDROID_GRADLE_PLUGIN_VERSION}" \
+        "${project_dir}/build.gradle" \
+        || fail "project Android Gradle Plugin differs from ${ANDROID_GRADLE_PLUGIN_VERSION}"
+    grep -Fq "gradle-${GRADLE_VERSION}-bin.zip" \
+        "${project_dir}/gradle/wrapper/gradle-wrapper.properties" \
+        || fail "project Gradle Wrapper differs from ${GRADLE_VERSION}"
+fi
+
+printf '%-28s %s\n' \
+    'Ubuntu' "$(. /etc/os-release && printf '%s' "${VERSION_ID}")" \
+    'Java' "$(java -version 2>&1 | head -n 1)" \
+    'Android command-line tools' "${ANDROID_CMDLINE_TOOLS_VERSION}" \
+    'Android compile SDK' "${ANDROID_COMPILE_SDK}" \
+    'Android build tools' "${ANDROID_BUILD_TOOLS_VERSION}" \
+    'Android NDK' "${ndk_revision}" \
+    'Gradle' "${gradle_version}" \
+    'Android Gradle Plugin' "${ANDROID_GRADLE_PLUGIN_VERSION}"
+
+if [[ -n "${project_dir}" ]]; then
+    printf '%-28s %s\n' 'Project configuration' 'matched'
+fi

--- a/dev/extensions/README.md
+++ b/dev/extensions/README.md
@@ -1,0 +1,53 @@
+# Extension development registry
+
+This registry identifies project-local extensions and their upstream integration points.
+Use the following stable marker format when preparing or reviewing a pull request:
+
+```text
+EXTENSION DEVELOPMENT [<extension-id>] [ADDED|MODIFIED]
+```
+
+- `ADDED` marks a file created and owned by an extension.
+- `MODIFIED` marks an integration point in an existing upstream file. Modified blocks use
+  matching `BEGIN` and `END` markers.
+- Extension IDs remain stable when code is moved or split.
+
+## EXT-IME-ACCESSORY-BAR
+
+- Change type: extension development
+- Status: experimental
+- Added: 2026-08-24
+- Purpose: display two rows of desktop shortcut keys directly above a docked Android system IME.
+- Added files:
+  - `app/src/main/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionController.java`
+  - `app/src/main/res/layout/extension_ime_keyboard_bar.xml`
+  - `app/src/main/res/drawable/extension_ime_keyboard_key.xml`
+  - `app/src/main/res/values/extension_ime_keyboard_styles.xml`
+- Modified files:
+  - `app/src/main/java/com/limelight/Game.java`
+- Upstream isolation: the controller owns its view, resources, IME observation, and key state;
+  `Game` only attaches it and forwards key events through the existing keyboard pipeline.
+
+## EXT-IME-AT-SIGN
+
+- Change type: compatibility extension development
+- Status: experimental
+- Added: 2026-08-24
+- Purpose: avoid Sunshine/Linux `Ctrl+Shift+U` Unicode composition for a single-character
+  Android IME commit of `@` by sending normalized `Shift+2` key packets instead.
+- Added files:
+  - `app/src/main/java/com/limelight/extensions/keyboard/ImeTextInputCompatibilityExtension.java`
+  - `app/src/test/java/com/limelight/extensions/keyboard/ImeTextInputCompatibilityExtensionTest.java`
+- Modified files:
+  - `app/src/main/java/com/limelight/Game.java`
+- Compatibility constraint: `Shift+2` assumes a US/QWERTY host keyboard layout. Other text and
+  multi-character commits remain on the original UTF-8 path.
+- Related upstream issue: `LizardByte/Sunshine#5274`.
+
+## Review lookup
+
+Locate all extension-owned files and upstream modifications with:
+
+```bash
+rg -n "EXTENSION DEVELOPMENT \[EXT-IME-(ACCESSORY-BAR|AT-SIGN)\]" app/src dev/extensions
+```


### PR DESCRIPTION
## 背景

- Android 系统软键盘弹出后，项目内置全键盘会被遮挡，常用桌面控制键难以实际使用。
- Android 软键盘会把 `@` 作为 UTF-8 文本提交。Linux 版 Sunshine 使用 `Ctrl+Shift+U` 注入 Unicode，在部分 KDE、Wayland、Chrome 或密码输入框中会停留在 `U+` 状态，无法输入 `@`。
- 项目此前缺少一套可复现、与 Gradle/Android NDK 配置严格匹配的 Ubuntu 26.04 开发环境。

## 修改内容

### EXT-IME-ACCESSORY-BAR

- 在停靠式 Android 系统软键盘上方增加两行快捷键：
  - `ESC, TAB, Unknown, HOME, ↑, END, PGUP`
  - `CMD, CTRL, ALT, ←, ↓, →, PGDN`
- CMD、CTRL、ALT 支持锁定；方向键及其他按键按触摸按下/抬起发送。
- CMD 发送标准 Meta 键，由被控端映射：Linux/Windows 为 Win，macOS 为 Command。
- 扩展视图由独立控制器动态挂载，不修改原有串流布局；浮动或分离式 IME 不显示按键栏。
- IME 隐藏、窗口失焦或 Activity 销毁时主动释放按键，避免远端残留修饰键状态。

### EXT-IME-AT-SIGN

- 对软键盘提交的单字符 `@` 增加客户端兼容映射，改发标准 `Shift+2` 按下/释放事件。
- 映射或发送失败时自动回退现有 UTF-8 文本路径。
- 其他字符及多字符提交保持原行为。
- 对应 Sunshine 已知问题：LizardByte/Sunshine#5274。

### Ubuntu 26.04 开发镜像

- 基于固定摘要的 `ubuntu:26.04`。
- 固定并校验 JDK 17、Gradle 8.7、Android SDK 34、Build Tools 34.0.0、NDK 27.0.12077973 和 Android Command-line Tools。
- 使用非 root 开发用户，并提供项目环境校验脚本和代码挂载说明。

## 扩展边界与审查标记

- 新增文件使用 `EXTENSION DEVELOPMENT [扩展ID] [ADDED]`。
- 对既有 `Game.java` 的修改使用成对的 `[MODIFIED] BEGIN/END`。
- 两项功能分别使用稳定 ID：`EXT-IME-ACCESSORY-BAR` 和 `EXT-IME-AT-SIGN`。
- `dev/extensions/README.md` 登记新增文件、修改文件、兼容性限制及审查检索方式。

## 兼容性说明

- `@ -> Shift+2` 假定被控端使用 US/QWERTY 键盘布局；非美式布局可能需要不同映射。
- 当前仅处理单字符 `@` 提交，避免拆分多字符 UTF-8 输入后产生跨通道顺序问题。

## 验证

在新增的 Ubuntu 26.04 开发容器中执行：

```bash
gradle --no-daemon testNonRootDebugUnitTest assembleNonRootDebug
```

结果：

- 7 个 JVM 单元测试通过，其中 4 个覆盖新增 `@` 兼容映射。
- `assembleNonRootDebug` 构建成功。
- `git diff --check` 通过。
