### PR TITLE
feat: 添加竖屏软键盘快捷按键栏与画面避让

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -26,6 +26,9 @@ import com.limelight.binding.video.PerfOverlayListener;
 import com.limelight.binding.video.PerfOverlayStats;
 import com.limelight.fsr.FsrVideoProcessor;
 import com.limelight.fsr.VideoProcessingGLSurfaceView;
+// EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+import com.limelight.extensions.keyboard.ImeKeyboardExtensionController;
+// EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
 import com.limelight.stereo3d.Stereo3dOutputLayout;
 import com.limelight.nvstream.MicUplinkConnection;
 import com.limelight.nvstream.NvConnection;
@@ -205,6 +208,10 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     private KeyBoardController keyBoardController;
 
     private KeyBoardLayoutController keyBoardLayoutController;
+
+    // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+    private ImeKeyboardExtensionController imeKeyboardExtensionController;
+    // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
 
     public PreferenceConfiguration prefConfig;
     private SharedPreferences tombstonePrefs;
@@ -933,6 +940,23 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         InputManager inputManager = (InputManager) getSystemService(Context.INPUT_SERVICE);
         inputManager.registerInputDeviceListener(keyboardTranslator, null);
 
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+        imeKeyboardExtensionController = new ImeKeyboardExtensionController(
+                this,
+                (FrameLayout) rootView,
+                (keyCode, down) -> keyboardEvent(down, (short) keyCode),
+                // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] BEGIN
+                streamView,
+                fsrView,
+                () -> {
+                    if (videoZoomController != null) {
+                        videoZoomController.refreshAfterHostSizeChanged();
+                    }
+                }
+                // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] END
+        );
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
+
         // Initialize touch contexts
 //        for (int i = 0; i < touchContextMap.length; i++) {
 //            if (!prefConfig.touchscreenTrackpad) {
@@ -1323,6 +1347,12 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
 
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+        if (!hasFocus && imeKeyboardExtensionController != null) {
+            imeKeyboardExtensionController.releasePressedKeys();
+        }
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
+
         // We can't guarantee the state of modifiers keys which may have
         // lifted while focus was not on us. Clear the modifier state.
         this.modifierFlags = 0;
@@ -1637,6 +1667,13 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         logSessionInfo("LIFECYCLE", "串流页面正在销毁");
         backgroundReconnectHandler.removeCallbacksAndMessages(null);
         releaseExternalDisplayRouting();
+
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] BEGIN
+        if (imeKeyboardExtensionController != null) {
+            imeKeyboardExtensionController.destroy();
+            imeKeyboardExtensionController = null;
+        }
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [MODIFIED] END
 
         if (virtualMouseOverlay != null) {
             virtualMouseOverlay.destroy();

--- a/app/src/main/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionController.java
+++ b/app/src/main/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionController.java
@@ -1,0 +1,314 @@
+package com.limelight.extensions.keyboard;
+
+import android.app.Activity;
+import android.content.res.Configuration;
+import android.graphics.Rect;
+import android.os.Build;
+import android.util.SparseArray;
+import android.util.SparseBooleanArray;
+import android.view.Gravity;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.view.WindowInsets;
+import android.view.WindowManager;
+import android.widget.FrameLayout;
+
+import com.limelight.R;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+ *
+ * <p>Adds PC shortcut keys immediately above a docked Android IME.</p>
+ *
+ * <p>This controller is intentionally self-contained. It mounts its own view at runtime, observes
+ * IME visibility, delegates local video-area reservation to a companion extension, and reports
+ * Android key codes through a small callback into the existing input pipeline.</p>
+ */
+public final class ImeKeyboardExtensionController {
+    public interface KeyDispatcher {
+        void dispatchKey(int keyCode, boolean down);
+    }
+
+    private static final int MIN_DOCKED_IME_HEIGHT_DP = 100;
+
+    private final Activity activity;
+    private final FrameLayout host;
+    private final KeyDispatcher keyDispatcher;
+    private final View keyboardBar;
+    private final Rect visibleDisplayFrame = new Rect();
+    private final SparseArray<View> momentaryKeyViews = new SparseArray<>();
+    private final SparseBooleanArray momentaryKeyStates = new SparseBooleanArray();
+    private final int minimumDockedImeHeightPx;
+    private final int originalSoftInputMode;
+
+    // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] BEGIN
+    private final ImeVideoViewportExtensionController videoViewportController;
+    private final Runnable videoViewportUpdateRunnable = this::updateVideoViewport;
+    // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] END
+
+    private final SparseArray<View> latchedKeyViews = new SparseArray<>();
+    private final SparseBooleanArray latchedKeyStates = new SparseBooleanArray();
+    private boolean destroyed;
+    private boolean lastVisible;
+    private int lastBottomMargin = Integer.MIN_VALUE;
+
+    private final ViewTreeObserver.OnGlobalLayoutListener globalLayoutListener =
+            this::updateKeyboardBarPosition;
+
+    public ImeKeyboardExtensionController(Activity activity, FrameLayout host,
+                                          KeyDispatcher keyDispatcher,
+                                          // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] BEGIN
+                                          View systemVideoView, View processedVideoView,
+                                          Runnable videoLayoutChangedCallback
+                                          // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] END
+    ) {
+        this.activity = activity;
+        this.host = host;
+        this.keyDispatcher = keyDispatcher;
+        this.minimumDockedImeHeightPx = Math.round(
+                MIN_DOCKED_IME_HEIGHT_DP * activity.getResources().getDisplayMetrics().density);
+        this.originalSoftInputMode = activity.getWindow().getAttributes().softInputMode;
+
+        // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] BEGIN
+        this.videoViewportController = new ImeVideoViewportExtensionController(
+                systemVideoView, processedVideoView, videoLayoutChangedCallback);
+        // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] END
+
+        keyboardBar = LayoutInflater.from(activity).inflate(
+                R.layout.extension_ime_keyboard_bar, host, false);
+        FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
+        layoutParams.gravity = Gravity.BOTTOM;
+        keyboardBar.setLayoutParams(layoutParams);
+        keyboardBar.setVisibility(View.GONE);
+
+        bindMomentaryKey(R.id.extension_key_escape, KeyEvent.KEYCODE_ESCAPE);
+        bindMomentaryKey(R.id.extension_key_tab, KeyEvent.KEYCODE_TAB);
+        bindMomentaryKey(R.id.extension_key_unknown, KeyEvent.KEYCODE_UNKNOWN);
+        bindMomentaryKey(R.id.extension_key_home, KeyEvent.KEYCODE_MOVE_HOME);
+        bindMomentaryKey(R.id.extension_key_up, KeyEvent.KEYCODE_DPAD_UP);
+        bindMomentaryKey(R.id.extension_key_end, KeyEvent.KEYCODE_MOVE_END);
+        bindMomentaryKey(R.id.extension_key_page_up, KeyEvent.KEYCODE_PAGE_UP);
+
+        bindLatchedKey(R.id.extension_key_cmd, KeyEvent.KEYCODE_META_LEFT);
+        bindLatchedKey(R.id.extension_key_ctrl, KeyEvent.KEYCODE_CTRL_LEFT);
+        bindLatchedKey(R.id.extension_key_alt, KeyEvent.KEYCODE_ALT_LEFT);
+        bindMomentaryKey(R.id.extension_key_left, KeyEvent.KEYCODE_DPAD_LEFT);
+        bindMomentaryKey(R.id.extension_key_down, KeyEvent.KEYCODE_DPAD_DOWN);
+        bindMomentaryKey(R.id.extension_key_right, KeyEvent.KEYCODE_DPAD_RIGHT);
+        bindMomentaryKey(R.id.extension_key_page_down, KeyEvent.KEYCODE_PAGE_DOWN);
+
+        host.addView(keyboardBar);
+        host.getViewTreeObserver().addOnGlobalLayoutListener(globalLayoutListener);
+
+        int resizeSoftInputMode = (originalSoftInputMode
+                & ~WindowManager.LayoutParams.SOFT_INPUT_MASK_ADJUST)
+                | WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE;
+        activity.getWindow().setSoftInputMode(resizeSoftInputMode);
+
+        host.post(this::updateKeyboardBarPosition);
+    }
+
+    private void bindMomentaryKey(int viewId, int keyCode) {
+        View keyView = keyboardBar.findViewById(viewId);
+        momentaryKeyViews.put(keyCode, keyView);
+        keyView.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View view, MotionEvent event) {
+                switch (event.getActionMasked()) {
+                    case MotionEvent.ACTION_DOWN:
+                        if (!momentaryKeyStates.get(keyCode)) {
+                            momentaryKeyStates.put(keyCode, true);
+                            view.setSelected(true);
+                            keyDispatcher.dispatchKey(keyCode, true);
+                        }
+                        return true;
+
+                    case MotionEvent.ACTION_UP:
+                        if (momentaryKeyStates.get(keyCode)) {
+                            momentaryKeyStates.delete(keyCode);
+                            view.setSelected(false);
+                            keyDispatcher.dispatchKey(keyCode, false);
+                        }
+                        view.performClick();
+                        return true;
+
+                    case MotionEvent.ACTION_CANCEL:
+                        if (momentaryKeyStates.get(keyCode)) {
+                            momentaryKeyStates.delete(keyCode);
+                            view.setSelected(false);
+                            keyDispatcher.dispatchKey(keyCode, false);
+                        }
+                        return true;
+
+                    default:
+                        return true;
+                }
+            }
+        });
+    }
+
+    private void bindLatchedKey(int viewId, int keyCode) {
+        View keyView = keyboardBar.findViewById(viewId);
+        latchedKeyViews.put(keyCode, keyView);
+        keyView.setOnClickListener(view -> {
+            boolean latched = !latchedKeyStates.get(keyCode);
+            if (latched) {
+                latchedKeyStates.put(keyCode, true);
+            }
+            else {
+                latchedKeyStates.delete(keyCode);
+            }
+
+            view.setSelected(latched);
+            keyDispatcher.dispatchKey(keyCode, latched);
+        });
+    }
+
+    private void updateKeyboardBarPosition() {
+        if (destroyed || !host.isAttachedToWindow()) {
+            return;
+        }
+
+        // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+        // The accessory and its video viewport reservation are portrait-only. Keeping the normal
+        // landscape streaming layout untouched also avoids reducing an already short IME viewport.
+        boolean accessoryEnabled = isAccessoryEnabledForOrientation(
+                activity.getResources().getConfiguration().orientation);
+
+        View decorView = activity.getWindow().getDecorView();
+        decorView.getWindowVisibleDisplayFrame(visibleDisplayFrame);
+
+        int[] decorLocation = new int[2];
+        int[] hostLocation = new int[2];
+        decorView.getLocationOnScreen(decorLocation);
+        host.getLocationOnScreen(hostLocation);
+
+        int decorBottom = decorLocation[1] + decorView.getHeight();
+        int hostBottom = hostLocation[1] + host.getHeight();
+        int keyboardTop = visibleDisplayFrame.bottom;
+        int obscuredHeight = Math.max(0, decorBottom - keyboardTop);
+
+        boolean imeVisible = accessoryEnabled
+                && obscuredHeight >= minimumDockedImeHeightPx;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            WindowInsets insets = host.getRootWindowInsets();
+            if (insets != null) {
+                int imeHeight = insets.getInsets(WindowInsets.Type.ime()).bottom;
+                // A floating or split IME does not expose a usable bottom edge. In that case,
+                // leave this docked accessory hidden instead of placing it at the wrong edge.
+                imeVisible = accessoryEnabled
+                        && insets.isVisible(WindowInsets.Type.ime())
+                        && imeHeight >= minimumDockedImeHeightPx;
+                if (imeVisible) {
+                    // WindowMetrics retains the full activity bounds even when adjustResize has
+                    // already shortened the content view. This avoids applying the IME height
+                    // twice on devices that honor adjustResize in fullscreen mode.
+                    Rect windowBounds = activity.getWindowManager()
+                            .getCurrentWindowMetrics().getBounds();
+                    keyboardTop = windowBounds.bottom - imeHeight;
+                }
+            }
+        }
+
+        int bottomMargin = imeVisible ? Math.max(0, hostBottom - keyboardTop) : 0;
+        applyVisibilityAndMargin(imeVisible, bottomMargin);
+
+        // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] BEGIN
+        keyboardBar.removeCallbacks(videoViewportUpdateRunnable);
+        if (imeVisible) {
+            // The bar may only receive its measured height after becoming visible. Resolve the
+            // viewport from its actual laid-out top on the next main-loop pass.
+            keyboardBar.post(videoViewportUpdateRunnable);
+        }
+        // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] END
+    }
+
+    // EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+    static boolean isAccessoryEnabledForOrientation(int orientation) {
+        return orientation != Configuration.ORIENTATION_LANDSCAPE;
+    }
+
+    private void applyVisibilityAndMargin(boolean visible, int bottomMargin) {
+        if (visible != lastVisible) {
+            lastVisible = visible;
+            keyboardBar.setVisibility(visible ? View.VISIBLE : View.GONE);
+            if (!visible) {
+                releasePressedKeys();
+                // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] BEGIN
+                videoViewportController.setReservedBottomInsetPx(0);
+                // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] END
+            }
+        }
+
+        if (visible && bottomMargin != lastBottomMargin) {
+            lastBottomMargin = bottomMargin;
+            FrameLayout.LayoutParams layoutParams =
+                    (FrameLayout.LayoutParams) keyboardBar.getLayoutParams();
+            layoutParams.bottomMargin = bottomMargin;
+            keyboardBar.setLayoutParams(layoutParams);
+        }
+    }
+
+    // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] BEGIN
+    private void updateVideoViewport() {
+        if (destroyed || !lastVisible || keyboardBar.getVisibility() != View.VISIBLE) {
+            videoViewportController.setReservedBottomInsetPx(0);
+            return;
+        }
+
+        int reservedBottomInsetPx = ImeVideoViewportExtensionController
+                .calculateReservedBottomInsetPx(host.getHeight(), keyboardBar.getTop());
+        videoViewportController.setReservedBottomInsetPx(reservedBottomInsetPx);
+    }
+    // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] END
+
+    private void releaseLatchedModifiers() {
+        for (int index = latchedKeyStates.size() - 1; index >= 0; index--) {
+            int keyCode = latchedKeyStates.keyAt(index);
+            View keyView = latchedKeyViews.get(keyCode);
+            if (keyView != null) {
+                keyView.setSelected(false);
+            }
+            keyDispatcher.dispatchKey(keyCode, false);
+        }
+        latchedKeyStates.clear();
+    }
+
+    public void releasePressedKeys() {
+        for (int index = momentaryKeyStates.size() - 1; index >= 0; index--) {
+            int keyCode = momentaryKeyStates.keyAt(index);
+            View keyView = momentaryKeyViews.get(keyCode);
+            if (keyView != null) {
+                keyView.setSelected(false);
+            }
+            keyDispatcher.dispatchKey(keyCode, false);
+        }
+        momentaryKeyStates.clear();
+        releaseLatchedModifiers();
+    }
+
+    public void destroy() {
+        if (destroyed) {
+            return;
+        }
+        destroyed = true;
+
+        // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] BEGIN
+        keyboardBar.removeCallbacks(videoViewportUpdateRunnable);
+        videoViewportController.destroy();
+        // EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [MODIFIED] END
+
+        releasePressedKeys();
+        ViewTreeObserver observer = host.getViewTreeObserver();
+        if (observer.isAlive()) {
+            observer.removeOnGlobalLayoutListener(globalLayoutListener);
+        }
+        host.removeView(keyboardBar);
+        activity.getWindow().setSoftInputMode(originalSoftInputMode);
+    }
+}

--- a/app/src/main/java/com/limelight/extensions/keyboard/ImeVideoViewportExtensionController.java
+++ b/app/src/main/java/com/limelight/extensions/keyboard/ImeVideoViewportExtensionController.java
@@ -1,0 +1,163 @@
+package com.limelight.extensions.keyboard;
+
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.FrameLayout;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [ADDED]
+ *
+ * <p>Reserves the area below the IME accessory bar for the system IME and the bar itself. The
+ * remote video remains a local rendering concern: stream resolution and decoder surface buffer
+ * size are not changed.</p>
+ *
+ * <p>The controller temporarily updates only the bottom margin and vertical gravity of the video
+ * views. Original values are restored when the IME is hidden or the extension is destroyed.</p>
+ */
+public final class ImeVideoViewportExtensionController {
+    private static final int UNSET_INSET = -1;
+
+    private final VideoViewLayoutState systemVideoViewState;
+    private final VideoViewLayoutState processedVideoViewState;
+    private final View layoutRefreshAnchor;
+    private final Runnable layoutChangedCallback;
+    private final View.OnLayoutChangeListener layoutChangeListener;
+
+    private boolean destroyed;
+    private int appliedBottomInsetPx = UNSET_INSET;
+
+    public ImeVideoViewportExtensionController(View systemVideoView,
+                                               View processedVideoView,
+                                               Runnable layoutChangedCallback) {
+        if (systemVideoView == null) {
+            throw new IllegalArgumentException("systemVideoView must not be null");
+        }
+
+        this.systemVideoViewState = new VideoViewLayoutState(systemVideoView);
+        this.processedVideoViewState = processedVideoView != null
+                && processedVideoView != systemVideoView
+                ? new VideoViewLayoutState(processedVideoView)
+                : null;
+        this.layoutRefreshAnchor = processedVideoView != null
+                ? processedVideoView
+                : systemVideoView;
+        this.layoutChangedCallback = layoutChangedCallback;
+        this.layoutChangeListener = (view, left, top, right, bottom,
+                                     oldLeft, oldTop, oldRight, oldBottom) -> {
+            if (!destroyed && layoutChangedCallback != null
+                    && (left != oldLeft || top != oldTop
+                    || right != oldRight || bottom != oldBottom)) {
+                layoutChangedCallback.run();
+            }
+        };
+        this.layoutRefreshAnchor.addOnLayoutChangeListener(layoutChangeListener);
+    }
+
+    /** Returns the host-space area from the accessory bar top through the host bottom. */
+    static int calculateReservedBottomInsetPx(int hostHeightPx, int accessoryBarTopPx) {
+        int safeHostHeight = Math.max(0, hostHeightPx);
+        int safeBarTop = Math.max(0, Math.min(accessoryBarTopPx, safeHostHeight));
+        return safeHostHeight - safeBarTop;
+    }
+
+    public void setReservedBottomInsetPx(int requestedBottomInsetPx) {
+        if (destroyed) {
+            return;
+        }
+
+        int bottomInsetPx = clampToParentHeight(Math.max(0, requestedBottomInsetPx));
+        if (appliedBottomInsetPx == bottomInsetPx) {
+            return;
+        }
+        appliedBottomInsetPx = bottomInsetPx;
+
+        systemVideoViewState.applyBottomInset(bottomInsetPx);
+        if (processedVideoViewState != null) {
+            processedVideoViewState.applyBottomInset(bottomInsetPx);
+        }
+    }
+
+    public void destroy() {
+        if (destroyed) {
+            return;
+        }
+        destroyed = true;
+        layoutRefreshAnchor.removeOnLayoutChangeListener(layoutChangeListener);
+        systemVideoViewState.restore();
+        if (processedVideoViewState != null) {
+            processedVideoViewState.restore();
+        }
+    }
+
+    private int clampToParentHeight(int bottomInsetPx) {
+        ViewParent parent = systemVideoViewState.view.getParent();
+        if (!(parent instanceof View)) {
+            return bottomInsetPx;
+        }
+
+        int parentHeight = ((View) parent).getHeight();
+        if (parentHeight <= 1) {
+            return bottomInsetPx;
+        }
+        return Math.min(bottomInsetPx, parentHeight - 1);
+    }
+
+    private static final class VideoViewLayoutState {
+        private final View view;
+        private final int originalBottomMargin;
+        private final int originalGravity;
+        private final boolean supportedLayoutParams;
+
+        VideoViewLayoutState(View view) {
+            this.view = view;
+            ViewGroup.LayoutParams rawLayoutParams = view.getLayoutParams();
+            if (rawLayoutParams instanceof FrameLayout.LayoutParams) {
+                FrameLayout.LayoutParams layoutParams =
+                        (FrameLayout.LayoutParams) rawLayoutParams;
+                originalBottomMargin = layoutParams.bottomMargin;
+                originalGravity = layoutParams.gravity;
+                supportedLayoutParams = true;
+            }
+            else {
+                originalBottomMargin = 0;
+                originalGravity = Gravity.NO_GRAVITY;
+                supportedLayoutParams = false;
+            }
+        }
+
+        void applyBottomInset(int bottomInsetPx) {
+            if (!supportedLayoutParams) {
+                return;
+            }
+
+            FrameLayout.LayoutParams layoutParams =
+                    (FrameLayout.LayoutParams) view.getLayoutParams();
+            int desiredBottomMargin = originalBottomMargin + bottomInsetPx;
+            int desiredGravity = bottomInsetPx == 0
+                    ? originalGravity
+                    : withBottomGravity(originalGravity);
+            if (layoutParams.bottomMargin == desiredBottomMargin
+                    && layoutParams.gravity == desiredGravity) {
+                return;
+            }
+
+            layoutParams.bottomMargin = desiredBottomMargin;
+            layoutParams.gravity = desiredGravity;
+            view.setLayoutParams(layoutParams);
+        }
+
+        void restore() {
+            applyBottomInset(0);
+        }
+
+        private static int withBottomGravity(int gravity) {
+            int resolvedGravity = gravity;
+            if (resolvedGravity == -1 || resolvedGravity == Gravity.NO_GRAVITY) {
+                resolvedGravity = Gravity.CENTER;
+            }
+            return (resolvedGravity & ~Gravity.VERTICAL_GRAVITY_MASK) | Gravity.BOTTOM;
+        }
+    }
+}

--- a/app/src/main/res/drawable/extension_ime_keyboard_key.xml
+++ b/app/src/main/res/drawable/extension_ime_keyboard_key.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+  Pressed and latched states for IME extension keys.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_selected="true">
+        <shape>
+            <solid android:color="#7C3AED" />
+            <stroke android:width="1dp" android:color="#C4B5FD" />
+            <corners android:radius="5dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape>
+            <solid android:color="#5B21B6" />
+            <stroke android:width="1dp" android:color="#A78BFA" />
+            <corners android:radius="5dp" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="#383838" />
+            <stroke android:width="1dp" android:color="#5A5A5A" />
+            <corners android:radius="5dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/extension_ime_keyboard_bar.xml
+++ b/app/src/main/res/layout/extension_ime_keyboard_bar.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+  Two-row PC shortcut bar displayed above a docked system IME.
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#F2212121"
+    android:clickable="true"
+    android:elevation="8dp"
+    android:focusable="false"
+    android:orientation="vertical"
+    android:padding="3dp"
+    tools:ignore="KeyboardInaccessibleWidget,Overdraw">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="38dp"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:weightSum="7">
+
+        <TextView
+            android:id="@+id/extension_key_escape"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_escape" />
+
+        <TextView
+            android:id="@+id/extension_key_tab"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_tab" />
+
+        <TextView
+            android:id="@+id/extension_key_unknown"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_unknown" />
+
+        <TextView
+            android:id="@+id/extension_key_home"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_home" />
+
+        <TextView
+            android:id="@+id/extension_key_up"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_up_description"
+            android:text="@string/extension_ime_key_up" />
+
+        <TextView
+            android:id="@+id/extension_key_end"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_end" />
+
+        <TextView
+            android:id="@+id/extension_key_page_up"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_page_up" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="38dp"
+        android:baselineAligned="false"
+        android:orientation="horizontal"
+        android:weightSum="7">
+
+        <TextView
+            android:id="@+id/extension_key_cmd"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_cmd_description"
+            android:text="@string/extension_ime_key_cmd" />
+
+        <TextView
+            android:id="@+id/extension_key_ctrl"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_ctrl_description"
+            android:text="@string/extension_ime_key_ctrl" />
+
+        <TextView
+            android:id="@+id/extension_key_alt"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_alt_description"
+            android:text="@string/extension_ime_key_alt" />
+
+        <TextView
+            android:id="@+id/extension_key_left"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_left_description"
+            android:text="@string/extension_ime_key_left" />
+
+        <TextView
+            android:id="@+id/extension_key_down"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_down_description"
+            android:text="@string/extension_ime_key_down" />
+
+        <TextView
+            android:id="@+id/extension_key_right"
+            style="@style/ImeKeyboardExtensionKey"
+            android:contentDescription="@string/extension_ime_key_right_description"
+            android:text="@string/extension_ime_key_right" />
+
+        <TextView
+            android:id="@+id/extension_key_page_down"
+            style="@style/ImeKeyboardExtensionKey"
+            android:text="@string/extension_ime_key_page_down" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/extension_ime_keyboard_styles.xml
+++ b/app/src/main/res/values/extension_ime_keyboard_styles.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+  Resources owned by the docked IME shortcut-bar extension.
+-->
+<resources>
+    <string name="extension_ime_key_escape" translatable="false">ESC</string>
+    <string name="extension_ime_key_unknown" translatable="false">Unknown</string>
+    <string name="extension_ime_key_home" translatable="false">HOME</string>
+    <string name="extension_ime_key_up" translatable="false">↑</string>
+    <string name="extension_ime_key_up_description" translatable="false">UP</string>
+    <string name="extension_ime_key_end" translatable="false">END</string>
+    <string name="extension_ime_key_page_up" translatable="false">PGUP</string>
+    <string name="extension_ime_key_tab" translatable="false">TAB</string>
+    <string name="extension_ime_key_cmd" translatable="false">CMD</string>
+    <string name="extension_ime_key_cmd_description" translatable="false">CMD，可锁定</string>
+    <string name="extension_ime_key_ctrl" translatable="false">CTRL</string>
+    <string name="extension_ime_key_ctrl_description" translatable="false">CTRL，可锁定</string>
+    <string name="extension_ime_key_alt" translatable="false">ALT</string>
+    <string name="extension_ime_key_alt_description" translatable="false">ALT，可锁定</string>
+    <string name="extension_ime_key_left" translatable="false">←</string>
+    <string name="extension_ime_key_left_description" translatable="false">LEFT</string>
+    <string name="extension_ime_key_down" translatable="false">↓</string>
+    <string name="extension_ime_key_down_description" translatable="false">DOWN</string>
+    <string name="extension_ime_key_right" translatable="false">→</string>
+    <string name="extension_ime_key_right_description" translatable="false">RIGHT</string>
+    <string name="extension_ime_key_page_down" translatable="false">PGDN</string>
+
+    <style name="ImeKeyboardExtensionKey">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">match_parent</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:layout_margin">2dp</item>
+        <item name="android:background">@drawable/extension_ime_keyboard_key</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">false</item>
+        <item name="android:gravity">center</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:textColor">@android:color/white</item>
+        <item name="android:textSize">11sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+</resources>

--- a/app/src/test/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionControllerTest.java
+++ b/app/src/test/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionControllerTest.java
@@ -1,0 +1,32 @@
+package com.limelight.extensions.keyboard;
+
+import android.content.res.Configuration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-ACCESSORY-BAR] [ADDED]
+ * Coverage for orientation-based accessory availability.
+ */
+public class ImeKeyboardExtensionControllerTest {
+    @Test
+    public void landscapeDisablesAccessoryBarAndViewportReservation() {
+        assertFalse(ImeKeyboardExtensionController.isAccessoryEnabledForOrientation(
+                Configuration.ORIENTATION_LANDSCAPE));
+    }
+
+    @Test
+    public void portraitEnablesAccessoryBar() {
+        assertTrue(ImeKeyboardExtensionController.isAccessoryEnabledForOrientation(
+                Configuration.ORIENTATION_PORTRAIT));
+    }
+
+    @Test
+    public void undefinedOrientationDoesNotDisableAccessoryBar() {
+        assertTrue(ImeKeyboardExtensionController.isAccessoryEnabledForOrientation(
+                Configuration.ORIENTATION_UNDEFINED));
+    }
+}

--- a/app/src/test/java/com/limelight/extensions/keyboard/ImeVideoViewportExtensionControllerTest.java
+++ b/app/src/test/java/com/limelight/extensions/keyboard/ImeVideoViewportExtensionControllerTest.java
@@ -1,0 +1,33 @@
+package com.limelight.extensions.keyboard;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-VIDEO-VIEWPORT] [ADDED]
+ * Coverage for host-space viewport inset calculations.
+ */
+public class ImeVideoViewportExtensionControllerTest {
+    @Test
+    public void resizedWindowReservesOnlyAccessoryBarArea() {
+        assertEquals(84, ImeVideoViewportExtensionController
+                .calculateReservedBottomInsetPx(500, 416));
+    }
+
+    @Test
+    public void fullscreenWindowReservesImeAndAccessoryBarArea() {
+        assertEquals(484, ImeVideoViewportExtensionController
+                .calculateReservedBottomInsetPx(900, 416));
+    }
+
+    @Test
+    public void accessoryBarTopIsClampedToHostBounds() {
+        assertEquals(500, ImeVideoViewportExtensionController
+                .calculateReservedBottomInsetPx(500, -20));
+        assertEquals(0, ImeVideoViewportExtensionController
+                .calculateReservedBottomInsetPx(500, 700));
+        assertEquals(0, ImeVideoViewportExtensionController
+                .calculateReservedBottomInsetPx(-1, 10));
+    }
+}

--- a/dev/extensions/EXT-IME-ACCESSORY-BAR.md
+++ b/dev/extensions/EXT-IME-ACCESSORY-BAR.md
@@ -1,0 +1,29 @@
+# EXT-IME-ACCESSORY-BAR
+
+- Change type: extension development
+- Status: experimental
+- Added: 2026-08-24
+- Purpose: display two rows of desktop shortcut keys directly above a docked Android system IME.
+- Key rows:
+  - `ESC, TAB, Unknown, HOME, ↑, END, PGUP`
+  - `CMD, CTRL, ALT, ←, ↓, →, PGDN`
+- Added files:
+  - `app/src/main/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionController.java`
+  - `app/src/main/java/com/limelight/extensions/keyboard/ImeVideoViewportExtensionController.java`
+  - `app/src/main/res/layout/extension_ime_keyboard_bar.xml`
+  - `app/src/main/res/drawable/extension_ime_keyboard_key.xml`
+  - `app/src/main/res/values/extension_ime_keyboard_styles.xml`
+  - `app/src/test/java/com/limelight/extensions/keyboard/ImeKeyboardExtensionControllerTest.java`
+  - `app/src/test/java/com/limelight/extensions/keyboard/ImeVideoViewportExtensionControllerTest.java`
+- Modified files:
+  - `app/src/main/java/com/limelight/Game.java`
+- Upstream isolation: the controllers own their views, resources, IME observation, key state,
+  inset calculation, and temporary video-view layout changes. `Game` only attaches the extension,
+  forwards keys through the existing keyboard pipeline, and supplies a video-layout callback.
+- Modifier behavior: `CMD`, `CTRL`, and `ALT` latch until tapped again. `CMD` emits the standard
+  Meta key, which is Win on Linux/Windows hosts and Command on macOS hosts.
+- Viewport behavior: while the portrait accessory is visible, the local remote-video view ends at
+  the accessory's top edge. Stream resolution and decoder surface buffer size are unchanged, and
+  original view layout values are restored when the IME is hidden or the extension is destroyed.
+- Presentation constraint: the accessory bar and viewport reservation are disabled in landscape;
+  floating or split IMEs do not show the docked accessory.

--- a/dev/extensions/README.md
+++ b/dev/extensions/README.md
@@ -1,0 +1,20 @@
+# Extension development registry
+
+Project-local extensions use stable markers so their owned files and upstream integration points
+remain easy to locate during review:
+
+```text
+EXTENSION DEVELOPMENT [<extension-id>] [ADDED|MODIFIED]
+```
+
+- `ADDED` marks a file created and owned by an extension.
+- `MODIFIED` marks an integration point in an existing upstream file. Modified blocks use matching
+  `BEGIN` and `END` markers.
+- Each extension has an independent detail file in this directory so unrelated extensions can be
+  reviewed and merged separately.
+
+Locate all registered extension changes with:
+
+```bash
+rg -n "EXTENSION DEVELOPMENT \[EXT-[^]]+\]" app/src dev/extensions
+```


### PR DESCRIPTION
## 背景

当前项目自带的全键盘会被 Android 系统软键盘覆盖，常用桌面控制键难以实际使用。新增按键栏后，还需要避免它遮挡被控端画面的本地显示区域，并确保横屏串流布局完全不受影响。

## 修改内容

### EXT-IME-ACCESSORY-BAR

- 在停靠式 Android 系统软键盘上方增加两行快捷键：
  - `ESC, TAB, Unknown, HOME, ↑, END, PGUP`
  - `CMD, CTRL, ALT, ←, ↓, →, PGDN`
- `CMD`、`CTRL`、`ALT` 支持锁定；方向键和其他功能键按触摸按下/抬起发送。
- `CMD` 发送标准 Meta 键：Linux/Windows 被控端表现为 Win，macOS 被控端表现为 Command。
- IME 隐藏、窗口失焦或 Activity 销毁时主动释放所有按下或锁定的按键，避免远端残留修饰键状态。
- 浮动式或分离式 IME 不显示停靠按键栏。

### EXT-IME-VIDEO-VIEWPORT

- 软键盘和按键栏显示时，临时保留按键栏顶部至窗口底部的本地区域，使远程画面下边缘紧贴按键栏上边缘，不再被遮挡。
- 仅调整本地视频 View 的底部边距和纵向重力，不修改串流分辨率、解码 Surface 缓冲尺寸或被控端桌面分辨率。
- IME 隐藏或扩展销毁时恢复视频 View 的原始布局参数。
- 横屏状态完全禁用按键栏和视口预留，不上移也不缩放画面。

## 扩展边界

- 控制器、布局、样式和测试均位于独立扩展文件中。
- `Game.java` 只负责挂载控制器、转发现有键盘事件，并提供视频布局刷新回调。
- 新增和修改点使用 `EXT-IME-ACCESSORY-BAR`、`EXT-IME-VIDEO-VIEWPORT` 的 `[ADDED]`/`[MODIFIED]` 标记。
- 本 PR 不包含 ASCII/字符输入兼容修改，也不包含开发镜像文件。

## 验证

在 Ubuntu 26.04 开发容器中，从上游 `master` 的干净分支执行：

```bash
gradle --no-daemon testNonRootDebugUnitTest assembleNonRootDebug
```

结果：

- 构建成功。
- 9 个 JVM 单元测试通过，0 失败；其中 6 个测试覆盖横竖屏启用规则和视口预留计算。
- 两个独立 PR 分支已通过 Git 三方合并测试，无内容冲突。
- `git diff --check` 通过。