### PR TITLE
fix: 修复 Android IME 可打印 ASCII 输入兼容性

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -35,6 +35,9 @@ import com.limelight.nvstream.http.ComputerDetails;
 import com.limelight.nvstream.http.NvApp;
 import com.limelight.nvstream.http.NvHTTP;
 import com.limelight.nvstream.input.KeyboardPacket;
+// EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] BEGIN
+import com.limelight.extensions.input.ImeAsciiInputExtension;
+// EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] END
 import com.limelight.nvstream.input.MouseButtonPacket;
 import com.limelight.nvstream.jni.MoonBridge;
 import com.limelight.haptics.PcmHapticsBackend;
@@ -2022,6 +2025,46 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         return (byte) modifierFlags;
     }
 
+    // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] BEGIN
+    private void sendImeCommittedText(String text) {
+        ImeAsciiInputExtension.KeyStroke[] keyStrokes = ImeAsciiInputExtension.mapText(text);
+        if (keyStrokes == null || !dispatchImeAsciiKeyStrokes(keyStrokes)) {
+            conn.sendUtf8Text(text);
+        }
+    }
+
+    private String getPrintableAsciiImeKeyEventText(KeyEvent event) {
+        if (event.getDeviceId() != KeyCharacterMap.VIRTUAL_KEYBOARD) {
+            return null;
+        }
+
+        int unicodeCharacter = event.getUnicodeChar();
+        if (!ImeAsciiInputExtension.isPrintableAscii(unicodeCharacter)) {
+            return null;
+        }
+
+        return String.valueOf((char) unicodeCharacter);
+    }
+
+    private boolean dispatchImeAsciiKeyStrokes(ImeAsciiInputExtension.KeyStroke[] keyStrokes) {
+        short[] keyMaps = new short[keyStrokes.length];
+        for (int i = 0; i < keyStrokes.length; i++) {
+            keyMaps[i] = keyboardTranslator.translate(keyStrokes[i].getAndroidKeyCode(), -1);
+            if (keyMaps[i] == 0) {
+                return false;
+            }
+        }
+
+        for (int i = 0; i < keyStrokes.length; i++) {
+            byte modifiers = (byte) ((getModifierState() & ~KeyboardPacket.MODIFIER_SHIFT)
+                    | keyStrokes[i].getRequiredModifiers());
+            conn.sendKeyboardInput(keyMaps[i], KeyboardPacket.KEY_DOWN, modifiers, (byte) 0);
+            conn.sendKeyboardInput(keyMaps[i], KeyboardPacket.KEY_UP, modifiers, (byte) 0);
+        }
+        return true;
+    }
+    // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] END
+
     private boolean isPhysicalKeyboardEscapeMenuEvent(KeyEvent event) {
         if (!prefConfig.keyboardEscOpensGameMenu || !connected
                 || event.getKeyCode() != KeyEvent.KEYCODE_ESCAPE
@@ -2107,6 +2150,16 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 return false;
             }
 
+            // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] BEGIN
+            // Some IMEs emit printable symbols as mapped key codes without their required Shift
+            // state. For example, KEYCODE_PLUS otherwise takes the raw '=' mapping below.
+            String imeAsciiText = getPrintableAsciiImeKeyEventText(event);
+            if (imeAsciiText != null) {
+                sendImeCommittedText(imeAsciiText);
+                return true;
+            }
+            // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] END
+
             // We'll send it as a raw key event if we have a key mapping, otherwise we'll send it
             // as UTF-8 text (if it's a printable character).
             short translated = keyboardTranslator.translate(event.getKeyCode(), event.getDeviceId());
@@ -2118,7 +2171,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 // UTF-8 events don't auto-repeat on the host side.
                 int unicodeChar = event.getUnicodeChar();
                 if ((unicodeChar & KeyCharacterMap.COMBINING_ACCENT) == 0 && (unicodeChar & KeyCharacterMap.COMBINING_ACCENT_MASK) != 0) {
-                    conn.sendUtf8Text(""+(char)unicodeChar);
+                    // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] BEGIN
+                    sendImeCommittedText(""+(char)unicodeChar);
+                    // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] END
                     return true;
                 }
 
@@ -2194,6 +2249,13 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 return false;
             }
 
+            // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] BEGIN
+            // Key down was emitted as a complete normalized stroke by the ASCII extension.
+            if (getPrintableAsciiImeKeyEventText(event) != null) {
+                return true;
+            }
+            // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] END
+
             short translated = keyboardTranslator.translate(event.getKeyCode(), event.getDeviceId());
             if (translated == 0) {
                 // If we sent this event as UTF-8 on key down, also report that it was handled
@@ -2227,7 +2289,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             return false;
         }
 
-        conn.sendUtf8Text(event.getCharacters());
+        // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] BEGIN
+        sendImeCommittedText(event.getCharacters());
+        // EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [MODIFIED] END
         return true;
     }
 

--- a/app/src/main/java/com/limelight/extensions/input/ImeAsciiInputExtension.java
+++ b/app/src/main/java/com/limelight/extensions/input/ImeAsciiInputExtension.java
@@ -1,0 +1,161 @@
+package com.limelight.extensions.input;
+
+import android.view.KeyEvent;
+
+import com.limelight.nvstream.input.KeyboardPacket;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [ADDED]
+ *
+ * <p>Maps printable ASCII text committed by an Android IME to normalized keyboard strokes.</p>
+ *
+ * <p>Sunshine on Linux may inject UTF-8 text through a Ctrl+Shift+U Unicode input sequence.
+ * Applications that do not support that sequence can display an unfinished {@code U+}
+ * composition. This extension avoids that path for printable ASCII while leaving all other text
+ * on Moonlight's original UTF-8 input path.</p>
+ *
+ * <p>These mappings assume a US/QWERTY host keyboard layout. The complete input is mapped before
+ * any key is sent, allowing the integration point to fall back without partially entering text.</p>
+ */
+public final class ImeAsciiInputExtension {
+    public static final class KeyStroke {
+        private final int androidKeyCode;
+        private final byte requiredModifiers;
+
+        private KeyStroke(int androidKeyCode, byte requiredModifiers) {
+            this.androidKeyCode = androidKeyCode;
+            this.requiredModifiers = requiredModifiers;
+        }
+
+        public int getAndroidKeyCode() {
+            return androidKeyCode;
+        }
+
+        public byte getRequiredModifiers() {
+            return requiredModifiers;
+        }
+    }
+
+    private ImeAsciiInputExtension() {
+    }
+
+    /**
+     * Maps a complete text commit to printable US/QWERTY ASCII key strokes.
+     *
+     * @return all mapped strokes, or {@code null} when the complete input must use the existing
+     *         UTF-8 path
+     */
+    public static KeyStroke[] mapText(String text) {
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+
+        KeyStroke[] keyStrokes = new KeyStroke[text.length()];
+        for (int i = 0; i < text.length(); i++) {
+            KeyStroke keyStroke = mapCharacter(text.charAt(i));
+            if (keyStroke == null) {
+                return null;
+            }
+            keyStrokes[i] = keyStroke;
+        }
+        return keyStrokes;
+    }
+
+    /**
+     * Returns whether a Unicode value can be handled by this extension as a single character.
+     */
+    public static boolean isPrintableAscii(int unicodeCharacter) {
+        return unicodeCharacter >= 0x20 && unicodeCharacter <= 0x7e;
+    }
+
+    private static KeyStroke mapCharacter(char character) {
+        if (character >= '0' && character <= '9') {
+            return unshifted(KeyEvent.KEYCODE_0 + character - '0');
+        }
+        if (character >= 'a' && character <= 'z') {
+            return unshifted(KeyEvent.KEYCODE_A + character - 'a');
+        }
+        if (character >= 'A' && character <= 'Z') {
+            return shifted(KeyEvent.KEYCODE_A + character - 'A');
+        }
+
+        switch (character) {
+            case ' ':
+                return unshifted(KeyEvent.KEYCODE_SPACE);
+            case '!':
+                return shifted(KeyEvent.KEYCODE_1);
+            case '"':
+                return shifted(KeyEvent.KEYCODE_APOSTROPHE);
+            case '#':
+                return shifted(KeyEvent.KEYCODE_3);
+            case '$':
+                return shifted(KeyEvent.KEYCODE_4);
+            case '%':
+                return shifted(KeyEvent.KEYCODE_5);
+            case '&':
+                return shifted(KeyEvent.KEYCODE_7);
+            case '\'':
+                return unshifted(KeyEvent.KEYCODE_APOSTROPHE);
+            case '(':
+                return shifted(KeyEvent.KEYCODE_9);
+            case ')':
+                return shifted(KeyEvent.KEYCODE_0);
+            case '*':
+                return shifted(KeyEvent.KEYCODE_8);
+            case '+':
+                return shifted(KeyEvent.KEYCODE_EQUALS);
+            case ',':
+                return unshifted(KeyEvent.KEYCODE_COMMA);
+            case '-':
+                return unshifted(KeyEvent.KEYCODE_MINUS);
+            case '.':
+                return unshifted(KeyEvent.KEYCODE_PERIOD);
+            case '/':
+                return unshifted(KeyEvent.KEYCODE_SLASH);
+            case ':':
+                return shifted(KeyEvent.KEYCODE_SEMICOLON);
+            case ';':
+                return unshifted(KeyEvent.KEYCODE_SEMICOLON);
+            case '<':
+                return shifted(KeyEvent.KEYCODE_COMMA);
+            case '=':
+                return unshifted(KeyEvent.KEYCODE_EQUALS);
+            case '>':
+                return shifted(KeyEvent.KEYCODE_PERIOD);
+            case '?':
+                return shifted(KeyEvent.KEYCODE_SLASH);
+            case '@':
+                return shifted(KeyEvent.KEYCODE_2);
+            case '[':
+                return unshifted(KeyEvent.KEYCODE_LEFT_BRACKET);
+            case '\\':
+                return unshifted(KeyEvent.KEYCODE_BACKSLASH);
+            case ']':
+                return unshifted(KeyEvent.KEYCODE_RIGHT_BRACKET);
+            case '^':
+                return shifted(KeyEvent.KEYCODE_6);
+            case '_':
+                return shifted(KeyEvent.KEYCODE_MINUS);
+            case '`':
+                return unshifted(KeyEvent.KEYCODE_GRAVE);
+            case '{':
+                return shifted(KeyEvent.KEYCODE_LEFT_BRACKET);
+            case '|':
+                return shifted(KeyEvent.KEYCODE_BACKSLASH);
+            case '}':
+                return shifted(KeyEvent.KEYCODE_RIGHT_BRACKET);
+            case '~':
+                return shifted(KeyEvent.KEYCODE_GRAVE);
+            default:
+                return null;
+        }
+    }
+
+    private static KeyStroke unshifted(int androidKeyCode) {
+        return new KeyStroke(androidKeyCode, (byte) 0);
+    }
+
+    private static KeyStroke shifted(int androidKeyCode) {
+        return new KeyStroke(androidKeyCode, KeyboardPacket.MODIFIER_SHIFT);
+    }
+}

--- a/app/src/test/java/com/limelight/extensions/input/ImeAsciiInputExtensionTest.java
+++ b/app/src/test/java/com/limelight/extensions/input/ImeAsciiInputExtensionTest.java
@@ -1,0 +1,134 @@
+package com.limelight.extensions.input;
+
+import android.view.KeyEvent;
+
+import com.limelight.nvstream.input.KeyboardPacket;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [ADDED]
+ * Coverage for complete printable-ASCII IME commit mapping.
+ */
+public class ImeAsciiInputExtensionTest {
+    @Test
+    public void mapsEveryPrintableAsciiCharacter() {
+        StringBuilder printableAscii = new StringBuilder();
+        for (char character = 0x20; character <= 0x7e; character++) {
+            printableAscii.append(character);
+        }
+
+        ImeAsciiInputExtension.KeyStroke[] keyStrokes =
+                ImeAsciiInputExtension.mapText(printableAscii.toString());
+
+        assertNotNull(keyStrokes);
+        assertEquals(95, keyStrokes.length);
+        for (ImeAsciiInputExtension.KeyStroke keyStroke : keyStrokes) {
+            assertNotNull(keyStroke);
+        }
+    }
+
+    @Test
+    public void mapsAtSignAsShiftTwo() {
+        assertSingleMapping("@", KeyEvent.KEYCODE_2, KeyboardPacket.MODIFIER_SHIFT);
+    }
+
+    @Test
+    public void mapsLetterCaseAndPunctuationModifiers() {
+        assertSingleMapping("a", KeyEvent.KEYCODE_A, (byte) 0);
+        assertSingleMapping("A", KeyEvent.KEYCODE_A, KeyboardPacket.MODIFIER_SHIFT);
+        assertSingleMapping("/", KeyEvent.KEYCODE_SLASH, (byte) 0);
+        assertSingleMapping("?", KeyEvent.KEYCODE_SLASH, KeyboardPacket.MODIFIER_SHIFT);
+        assertSingleMapping("=", KeyEvent.KEYCODE_EQUALS, (byte) 0);
+        assertSingleMapping("+", KeyEvent.KEYCODE_EQUALS, KeyboardPacket.MODIFIER_SHIFT);
+        assertSingleMapping("[", KeyEvent.KEYCODE_LEFT_BRACKET, (byte) 0);
+        assertSingleMapping("{", KeyEvent.KEYCODE_LEFT_BRACKET, KeyboardPacket.MODIFIER_SHIFT);
+    }
+
+    @Test
+    public void mapsEveryShiftedUsQwertySymbolToItsBaseKey() {
+        String shiftedSymbols = "!\"#$%&()*+:<>?@^_{|}~";
+        int[] expectedKeyCodes = {
+                KeyEvent.KEYCODE_1,
+                KeyEvent.KEYCODE_APOSTROPHE,
+                KeyEvent.KEYCODE_3,
+                KeyEvent.KEYCODE_4,
+                KeyEvent.KEYCODE_5,
+                KeyEvent.KEYCODE_7,
+                KeyEvent.KEYCODE_9,
+                KeyEvent.KEYCODE_0,
+                KeyEvent.KEYCODE_8,
+                KeyEvent.KEYCODE_EQUALS,
+                KeyEvent.KEYCODE_SEMICOLON,
+                KeyEvent.KEYCODE_COMMA,
+                KeyEvent.KEYCODE_PERIOD,
+                KeyEvent.KEYCODE_SLASH,
+                KeyEvent.KEYCODE_2,
+                KeyEvent.KEYCODE_6,
+                KeyEvent.KEYCODE_MINUS,
+                KeyEvent.KEYCODE_LEFT_BRACKET,
+                KeyEvent.KEYCODE_BACKSLASH,
+                KeyEvent.KEYCODE_RIGHT_BRACKET,
+                KeyEvent.KEYCODE_GRAVE,
+        };
+
+        ImeAsciiInputExtension.KeyStroke[] keyStrokes =
+                ImeAsciiInputExtension.mapText(shiftedSymbols);
+
+        assertNotNull(keyStrokes);
+        assertEquals(expectedKeyCodes.length, keyStrokes.length);
+        for (int i = 0; i < expectedKeyCodes.length; i++) {
+            assertEquals(expectedKeyCodes[i], keyStrokes[i].getAndroidKeyCode());
+            assertEquals(KeyboardPacket.MODIFIER_SHIFT,
+                    keyStrokes[i].getRequiredModifiers());
+        }
+    }
+
+    @Test
+    public void recognizesOnlySinglePrintableAsciiCodePoints() {
+        assertTrue(ImeAsciiInputExtension.isPrintableAscii(0x20));
+        assertTrue(ImeAsciiInputExtension.isPrintableAscii(0x7e));
+        assertFalse(ImeAsciiInputExtension.isPrintableAscii(0x1f));
+        assertFalse(ImeAsciiInputExtension.isPrintableAscii(0x7f));
+        assertFalse(ImeAsciiInputExtension.isPrintableAscii('中'));
+    }
+
+    @Test
+    public void mapsCompleteMultiCharacterCommitInOrder() {
+        ImeAsciiInputExtension.KeyStroke[] keyStrokes =
+                ImeAsciiInputExtension.mapText("name@example.com");
+
+        assertNotNull(keyStrokes);
+        assertEquals(16, keyStrokes.length);
+        assertEquals(KeyEvent.KEYCODE_N, keyStrokes[0].getAndroidKeyCode());
+        assertEquals(KeyEvent.KEYCODE_2, keyStrokes[4].getAndroidKeyCode());
+        assertEquals(KeyboardPacket.MODIFIER_SHIFT, keyStrokes[4].getRequiredModifiers());
+        assertEquals(KeyEvent.KEYCODE_PERIOD, keyStrokes[12].getAndroidKeyCode());
+        assertEquals(KeyEvent.KEYCODE_M, keyStrokes[15].getAndroidKeyCode());
+    }
+
+    @Test
+    public void rejectsIncompleteOrNonAsciiCommitWithoutPartialMapping() {
+        assertNull(ImeAsciiInputExtension.mapText(null));
+        assertNull(ImeAsciiInputExtension.mapText(""));
+        assertNull(ImeAsciiInputExtension.mapText("中文"));
+        assertNull(ImeAsciiInputExtension.mapText("abc中"));
+        assertNull(ImeAsciiInputExtension.mapText("line\nbreak"));
+    }
+
+    private static void assertSingleMapping(String text, int keyCode, byte modifiers) {
+        ImeAsciiInputExtension.KeyStroke[] keyStrokes =
+                ImeAsciiInputExtension.mapText(text);
+
+        assertNotNull(keyStrokes);
+        assertEquals(1, keyStrokes.length);
+        assertEquals(keyCode, keyStrokes[0].getAndroidKeyCode());
+        assertEquals(modifiers, keyStrokes[0].getRequiredModifiers());
+    }
+}

--- a/dev/extensions/EXT-IME-ASCII-INPUT.md
+++ b/dev/extensions/EXT-IME-ASCII-INPUT.md
@@ -1,0 +1,24 @@
+# EXT-IME-ASCII-INPUT
+
+- Change type: compatibility extension development
+- Status: experimental
+- Added: 2026-08-24
+- Purpose: avoid Sunshine/Linux `Ctrl+Shift+U` Unicode composition for Android IME commits
+  containing printable ASCII by sending normalized keyboard packets instead.
+- Added files:
+  - `app/src/main/java/com/limelight/extensions/input/ImeAsciiInputExtension.java`
+  - `app/src/test/java/com/limelight/extensions/input/ImeAsciiInputExtensionTest.java`
+- Modified files:
+  - `app/src/main/java/com/limelight/Game.java`
+- Upstream isolation: the extension has no dependency on the IME accessory bar or video viewport;
+  `Game` only routes committed text and printable virtual-keyboard events through it, then sends the
+  returned normalized strokes.
+- Atomic fallback: a complete commit is mapped and translated before the first key packet is sent,
+  preventing a partially sent commit from being duplicated by UTF-8 fallback.
+- Virtual-key compatibility: printable events from Android's virtual keyboard are routed before the
+  original raw-key translation. This preserves required Shift state for dedicated events such as
+  `KEYCODE_PLUS`, which otherwise translates to the unshifted `=` base key.
+- Compatibility constraint: printable ASCII mappings assume a US/QWERTY host keyboard layout.
+  Empty commits, control characters, non-ASCII text, and mixed unsupported commits remain on the
+  original UTF-8 path.
+- Related upstream issue: `LizardByte/Sunshine#5274`.

--- a/dev/extensions/README.md
+++ b/dev/extensions/README.md
@@ -1,0 +1,20 @@
+# Extension development registry
+
+Project-local extensions use stable markers so their owned files and upstream integration points
+remain easy to locate during review:
+
+```text
+EXTENSION DEVELOPMENT [<extension-id>] [ADDED|MODIFIED]
+```
+
+- `ADDED` marks a file created and owned by an extension.
+- `MODIFIED` marks an integration point in an existing upstream file. Modified blocks use matching
+  `BEGIN` and `END` markers.
+- Each extension has an independent detail file in this directory so unrelated extensions can be
+  reviewed and merged separately.
+
+Locate all registered extension changes with:
+
+```bash
+rg -n "EXTENSION DEVELOPMENT \[EXT-[^]]+\]" app/src dev/extensions
+```


### PR DESCRIPTION
## 背景

Android 系统软键盘可能通过两种路径提交字符：未知键的文本提交，以及带有可翻译键码的虚拟键事件。Linux 版 Sunshine 的 UTF-8 注入在部分应用中可能停留在 `U+` Unicode 组合状态；同时，`KEYCODE_PLUS` 等虚拟键事件会绕过文本兼容路径，使 `+` 因缺少 Shift 而退化为 `=`。

## 修改内容

### EXT-IME-ASCII-INPUT

- 将全部 95 个可打印 ASCII 字符（`U+0020` 至 `U+007E`）映射为标准 US/QWERTY 键码及必要的 Shift 修饰位。
- 同时接管 IME 文本提交和 Android 虚拟键盘产生的可打印 ASCII 单键事件，修复 `@` 显示为 `U+`、`+` 输入为 `=`，以及其他 Shift 符号可能丢失修饰位的问题。
- 吞掉已经作为完整标准按键发送的虚拟键 KeyUp，避免重复释放或重复输入。
- 在发送第一个按键包之前完整映射并翻译整段提交；任一字符不支持时整段回退原 UTF-8 路径，避免部分发送后重复回退。
- 非 ASCII、控制字符、空输入和混合不支持内容保持项目原有 UTF-8 行为。
- 扩展位于独立的 `extensions.input` 包，不依赖软键盘按键栏或视频视口扩展。

## 兼容性说明

- 映射假定被控端使用 US/QWERTY 键盘布局；非美式布局的符号位置可能不同。
- 覆盖的 Shift 符号包括：`! " # $ % & ( ) * + : < > ? @ ^ _ { | } ~`，并处理大写 `A-Z`。
- 对应 Sunshine 已知问题：LizardByte/Sunshine#5274。

## 扩展边界

- 新增文件使用 `EXTENSION DEVELOPMENT [EXT-IME-ASCII-INPUT] [ADDED]`。
- `Game.java` 接入点使用成对的 `[MODIFIED] BEGIN/END` 标记。
- `dev/extensions/EXT-IME-ASCII-INPUT.md` 独立登记扩展边界，便于单独审查和后续维护。

## 验证

在 Ubuntu 26.04 开发容器中，从上游 `master` 的干净分支执行：

```bash
gradle --no-daemon testNonRootDebugUnitTest assembleNonRootDebug
```

结果：

- 构建成功。
- 10 个 JVM 单元测试通过，0 失败；其中 7 个测试覆盖 ASCII 扩展。
- 逐项验证全部 95 个可打印 ASCII，以及全部 21 个需要 Shift 的 US/QWERTY 符号。
- `git diff --check` 通过。