### PR TITLE
feat: 添加独立多手势触控板模式

### DIFF
--- a/app/src/main/java/com/limelight/Game.java
+++ b/app/src/main/java/com/limelight/Game.java
@@ -16,6 +16,9 @@ import com.limelight.binding.input.driver.UsbDriverService;
 import com.limelight.binding.input.evdev.EvdevListener;
 import com.limelight.binding.input.touch.RelativeTouchSwitchContext;
 import com.limelight.binding.input.touch.TouchContext;
+// EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+import com.limelight.extensions.input.touch.MultiGestureTouchpadExtensionController;
+// EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
 import com.limelight.binding.input.virtual_controller.VirtualController;
 import com.limelight.binding.input.virtual_controller.keyboard.KeyBoardController;
 import com.limelight.binding.input.virtual_controller.keyboard.KeyBoardLayoutController;
@@ -242,6 +245,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
     private VirtualMouseOverlay virtualMouseOverlay;
     private VideoZoomController videoZoomController;
     private VideoZoomGestureOverlay videoZoomGestureOverlay;
+    // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+    private MultiGestureTouchpadExtensionController multiGestureTouchpadController;
+    // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
     private final PointF videoZoomTapPoint = new PointF();
     private final PointF videoZoomInputPoint = new PointF();
     private final RectF videoZoomBaseRect = new RectF();
@@ -1642,6 +1648,12 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             virtualMouseOverlay.destroy();
             virtualMouseOverlay = null;
         }
+        // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+        if (multiGestureTouchpadController != null) {
+            multiGestureTouchpadController.destroy();
+            multiGestureTouchpadController = null;
+        }
+        // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
         if (videoZoomGestureOverlay != null) {
             videoZoomGestureOverlay.destroy();
             videoZoomGestureOverlay = null;
@@ -2947,6 +2959,11 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                                 for (TouchContext aTouchContext : touchContextMap) {
                                     aTouchContext.cancelTouch();
                                 }
+                                // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+                                if (multiGestureTouchpadController != null) {
+                                    multiGestureTouchpadController.cancelUntilNextGesture();
+                                }
+                                // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
                                 return true;
                             }
                             break;
@@ -2996,8 +3013,23 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                         aTouchContext.cancelTouch();
                     }
 
+                    // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+                    if (multiGestureTouchpadController != null) {
+                        multiGestureTouchpadController.cancelUntilNextGesture();
+                    }
+                    // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
+
                     return true;
                 }
+
+                // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+                // This mode needs the complete MotionEvent to classify scroll and pinch before
+                // the legacy path splits it into independent per-pointer contexts.
+                if (multiGestureTouchpadController != null
+                        && multiGestureTouchpadController.onTouchEvent(view, event)) {
+                    return true;
+                }
+                // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
 
                 TouchContext context = getTouchContext(actionIndex);
                 if (context == null) {
@@ -4205,6 +4237,12 @@ public class Game extends Activity implements SurfaceHolder.Callback,
 
     public void switchMouseModel(int which){
         disableMouseModel=false;
+        // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+        if (multiGestureTouchpadController != null) {
+            multiGestureTouchpadController.destroy();
+            multiGestureTouchpadController = null;
+        }
+        // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
         //多点触控
         if(which==0){
             prefConfig.enableMultiTouchScreen=true;
@@ -4223,6 +4261,11 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         //禁用鼠标
         if(which==3){
             disableMouseModel=true;
+            // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+            // Refresh overlay routing after the extension controller was detached above.
+            setVirtualMouseInputSuppressed(false);
+            setVideoZoomInputSuppressed(false);
+            // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
             return;
         }
         //普通鼠标 左右键互换
@@ -4242,6 +4285,21 @@ public class Game extends Activity implements SurfaceHolder.Callback,
             prefConfig.enableMultiTouchScreen=false;
             prefConfig.touchscreenTrackpad=true;
         }
+
+        // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+        // Dedicated mode for the isolated multi-gesture touchpad extension.
+        if(which==MultiGestureTouchpadExtensionController.MODE_ID){
+            prefConfig.enableMultiTouchScreen=false;
+            prefConfig.touchscreenTrackpad=true;
+            multiGestureTouchpadController = new MultiGestureTouchpadExtensionController(
+                    this,
+                    conn,
+                    streamView,
+                    (View) rootView,
+                    prefConfig,
+                    videoZoomController);
+        }
+        // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
 
         for (int i = 0; i < touchContextMap.length; i++) {
             if (!prefConfig.touchscreenTrackpad) {
@@ -4263,6 +4321,12 @@ public class Game extends Activity implements SurfaceHolder.Callback,
                 }
             }
         }
+
+        // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+        // Hide other full-screen touch layers while this mode owns touchscreen gestures.
+        setVirtualMouseInputSuppressed(false);
+        setVideoZoomInputSuppressed(false);
+        // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
     }
 
     public void showHUD(){
@@ -4668,6 +4732,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         virtualMouseOverlay.setInputSuppressed(suppressed
                 || disableMouseModel
                 || getScreenMoveZoom()
+                // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+                || multiGestureTouchpadController != null
+                // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
                 || isHidingOverlays
                 || gameMenuShowing
                 || fullKeyboardShowing
@@ -4685,6 +4752,9 @@ public class Game extends Activity implements SurfaceHolder.Callback,
         boolean fullKeyboardShowing = keyBoardLayoutController != null
                 && keyBoardLayoutController.isVisible();
         videoZoomGestureOverlay.setInputSuppressed(suppressed
+                // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+                || multiGestureTouchpadController != null
+                // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
                 || isHidingOverlays
                 || gameMenuShowing
                 || fullKeyboardShowing

--- a/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureCursorTracker.java
+++ b/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureCursorTracker.java
@@ -1,0 +1,41 @@
+package com.limelight.extensions.input.touch;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED]
+ *
+ * Owns the reference plane shared by the multi-gesture mode's absolute cursor packets and local
+ * edge-follow position. Keeping both users here prevents their coordinates drifting solely because
+ * the Android video view has different dimensions.
+ */
+final class MultiGestureCursorTracker {
+    static final short REFERENCE_WIDTH = 1280;
+    static final short REFERENCE_HEIGHT = 720;
+
+    private int referenceX = REFERENCE_WIDTH / 2;
+    private int referenceY = REFERENCE_HEIGHT / 2;
+
+    void move(short deltaX, short deltaY) {
+        referenceX = clamp(referenceX + deltaX, 0, REFERENCE_WIDTH - 1);
+        referenceY = clamp(referenceY + deltaY, 0, REFERENCE_HEIGHT - 1);
+    }
+
+    short getReferenceX() {
+        return (short) referenceX;
+    }
+
+    short getReferenceY() {
+        return (short) referenceY;
+    }
+
+    float getNormalizedX() {
+        return referenceX / (float) (REFERENCE_WIDTH - 1);
+    }
+
+    float getNormalizedY() {
+        return referenceY / (float) (REFERENCE_HEIGHT - 1);
+    }
+
+    private static int clamp(int value, int minimum, int maximum) {
+        return Math.max(minimum, Math.min(maximum, value));
+    }
+}

--- a/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureEdgePanCalculator.java
+++ b/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureEdgePanCalculator.java
@@ -1,0 +1,54 @@
+package com.limelight.extensions.input.touch;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED]
+ *
+ * Calculates the video-pan delta required to keep the tracked remote cursor inside a local
+ * viewport edge inset. VideoZoomController remains responsible for clamping at content bounds.
+ */
+final class MultiGestureEdgePanCalculator {
+    private MultiGestureEdgePanCalculator() {
+    }
+
+    static void calculate(float cursorX, float cursorY,
+                          float viewportLeft, float viewportTop,
+                          float viewportRight, float viewportBottom,
+                          float contentLeft, float contentTop,
+                          float contentRight, float contentBottom,
+                          float edgeInset, float[] outDelta) {
+        if (outDelta == null || outDelta.length < 2) {
+            throw new IllegalArgumentException("outDelta must contain at least two elements");
+        }
+
+        outDelta[0] = calculateAxis(
+                cursorX, viewportLeft, viewportRight, contentLeft, contentRight, edgeInset);
+        outDelta[1] = calculateAxis(
+                cursorY, viewportTop, viewportBottom, contentTop, contentBottom, edgeInset);
+    }
+
+    private static float calculateAxis(float cursor, float viewportStart, float viewportEnd,
+                                       float contentStart, float contentEnd, float edgeInset) {
+        float viewportSize = viewportEnd - viewportStart;
+        if (viewportSize <= 0f || edgeInset <= 0f) {
+            return 0f;
+        }
+
+        float inset = Math.min(edgeInset, viewportSize * 0.5f);
+        float nearEdge = viewportStart + inset;
+        if (cursor < nearEdge) {
+            float hiddenDistance = viewportStart - contentStart;
+            return hiddenDistance > 0f
+                    ? Math.min(nearEdge - cursor, hiddenDistance)
+                    : 0f;
+        }
+
+        float farEdge = viewportEnd - inset;
+        if (cursor > farEdge) {
+            float hiddenDistance = contentEnd - viewportEnd;
+            return hiddenDistance > 0f
+                    ? Math.max(farEdge - cursor, -hiddenDistance)
+                    : 0f;
+        }
+        return 0f;
+    }
+}

--- a/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureTouchContext.java
+++ b/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureTouchContext.java
@@ -1,0 +1,254 @@
+package com.limelight.extensions.input.touch;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED]
+ *
+ * A platform-independent gesture state machine for the multi-gesture touchpad mode. Android's
+ * pointer events are adapted by {@link MultiGestureTouchpadExtensionController}; keeping the
+ * classifier independent makes gesture precedence and release-order handling directly testable.
+ */
+final class MultiGestureTouchContext {
+    // Values intentionally match android.view.MotionEvent action constants.
+    static final int ACTION_DOWN = 0;
+    static final int ACTION_UP = 1;
+    static final int ACTION_MOVE = 2;
+    static final int ACTION_CANCEL = 3;
+    static final int ACTION_POINTER_DOWN = 5;
+    static final int ACTION_POINTER_UP = 6;
+
+    interface Listener {
+        void onPointerMove(float deltaX, float deltaY);
+        void onVerticalScroll(float deltaY);
+        void onZoom(float scaleFactor, float focusX, float focusY);
+        void onLeftClick();
+        void onRightClick();
+    }
+
+    private enum State {
+        IDLE,
+        SINGLE,
+        TWO_UNDECIDED,
+        TWO_SCROLL,
+        TWO_PINCH,
+        WAIT_FOR_ALL_UP
+    }
+
+    private final Listener listener;
+    private final float tapMovementSlop;
+    private final float scrollActivationDistance;
+    private final float pinchActivationDistance;
+    private final float pinchActivationRatio;
+    private final long tapTimeoutMs;
+
+    private State state = State.IDLE;
+    private long gestureDownTime;
+    private float singleStartX;
+    private float singleStartY;
+    private float singleLastX;
+    private float singleLastY;
+    private float singleMaximumTravel;
+    private final float[] twoStartX = new float[2];
+    private final float[] twoStartY = new float[2];
+    private float twoMaximumTravel;
+    private float twoInitialSpan;
+    private float twoLastSpan;
+    private float twoInitialFocusX;
+    private float twoInitialFocusY;
+    private float twoLastFocusY;
+    private boolean pendingTwoFingerTap;
+
+    MultiGestureTouchContext(Listener listener,
+                             float tapMovementSlop,
+                             float scrollActivationDistance,
+                             float pinchActivationDistance,
+                             float pinchActivationRatio,
+                             long tapTimeoutMs) {
+        this.listener = listener;
+        this.tapMovementSlop = tapMovementSlop;
+        this.scrollActivationDistance = scrollActivationDistance;
+        this.pinchActivationDistance = pinchActivationDistance;
+        this.pinchActivationRatio = pinchActivationRatio;
+        this.tapTimeoutMs = tapTimeoutMs;
+    }
+
+    /**
+     * Consumes a normalized pointer frame. Only the first two coordinates are required when more
+     * than two pointers are present, because such gestures are deliberately ignored here.
+     */
+    boolean onTouchEvent(int action, int actionIndex, int pointerCount,
+                         float[] x, float[] y, long eventTime) {
+        int requiredCoordinates = Math.min(pointerCount, 2);
+        if (pointerCount < 1 || x == null || y == null
+                || x.length < requiredCoordinates || y.length < requiredCoordinates) {
+            cancel();
+            return false;
+        }
+
+        switch (action) {
+            case ACTION_DOWN:
+                beginSingle(x[0], y[0], eventTime);
+                return true;
+
+            case ACTION_POINTER_DOWN:
+                if (pointerCount == 2) {
+                    beginTwoFinger(x, y);
+                }
+                else {
+                    state = State.WAIT_FOR_ALL_UP;
+                    pendingTwoFingerTap = false;
+                }
+                return true;
+
+            case ACTION_MOVE:
+                if (state == State.SINGLE && pointerCount == 1) {
+                    updateSingle(x[0], y[0]);
+                }
+                else if (pointerCount >= 2 && isTwoFingerState()) {
+                    updateTwoFinger(x, y);
+                }
+                return true;
+
+            case ACTION_POINTER_UP:
+                if (pointerCount == 2 && isTwoFingerState()) {
+                    updateTwoFinger(x, y);
+                    pendingTwoFingerTap = state == State.TWO_UNDECIDED
+                            && isWithinTapTime(eventTime)
+                            && twoMaximumTravel <= tapMovementSlop;
+                }
+                else {
+                    pendingTwoFingerTap = false;
+                }
+                state = State.WAIT_FOR_ALL_UP;
+                return true;
+
+            case ACTION_UP:
+                finishGesture(x[0], y[0], eventTime);
+                return true;
+
+            case ACTION_CANCEL:
+                cancel();
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    void cancel() {
+        state = State.IDLE;
+        pendingTwoFingerTap = false;
+        singleMaximumTravel = 0f;
+        twoMaximumTravel = 0f;
+    }
+
+    private void beginSingle(float x, float y, long eventTime) {
+        cancel();
+        state = State.SINGLE;
+        gestureDownTime = eventTime;
+        singleStartX = singleLastX = x;
+        singleStartY = singleLastY = y;
+    }
+
+    private void updateSingle(float x, float y) {
+        singleMaximumTravel = Math.max(singleMaximumTravel,
+                distance(singleStartX, singleStartY, x, y));
+        float deltaX = x - singleLastX;
+        float deltaY = y - singleLastY;
+        singleLastX = x;
+        singleLastY = y;
+        if (deltaX != 0f || deltaY != 0f) {
+            listener.onPointerMove(deltaX, deltaY);
+        }
+    }
+
+    private void beginTwoFinger(float[] x, float[] y) {
+        state = State.TWO_UNDECIDED;
+        pendingTwoFingerTap = false;
+        twoStartX[0] = x[0];
+        twoStartX[1] = x[1];
+        twoStartY[0] = y[0];
+        twoStartY[1] = y[1];
+        twoMaximumTravel = 0f;
+        twoInitialSpan = twoLastSpan = distance(x[0], y[0], x[1], y[1]);
+        twoInitialFocusX = (x[0] + x[1]) * 0.5f;
+        twoInitialFocusY = twoLastFocusY = (y[0] + y[1]) * 0.5f;
+    }
+
+    private void updateTwoFinger(float[] x, float[] y) {
+        twoMaximumTravel = Math.max(twoMaximumTravel,
+                Math.max(distance(twoStartX[0], twoStartY[0], x[0], y[0]),
+                        distance(twoStartX[1], twoStartY[1], x[1], y[1])));
+
+        float span = distance(x[0], y[0], x[1], y[1]);
+        float focusX = (x[0] + x[1]) * 0.5f;
+        float focusY = (y[0] + y[1]) * 0.5f;
+
+        if (state == State.TWO_UNDECIDED) {
+            float spanDelta = Math.abs(span - twoInitialSpan);
+            float spanRatio = spanDelta / Math.max(twoInitialSpan, 1f);
+            float focusDeltaX = focusX - twoInitialFocusX;
+            float focusDeltaY = focusY - twoInitialFocusY;
+
+            // Pinch takes precedence once both absolute and relative evidence are present.
+            if (spanDelta >= pinchActivationDistance && spanRatio >= pinchActivationRatio) {
+                state = State.TWO_PINCH;
+                dispatchZoom(twoInitialSpan, span, focusX, focusY);
+            }
+            else if (Math.abs(focusDeltaY) >= scrollActivationDistance
+                    && Math.abs(focusDeltaY) >= Math.abs(focusDeltaX)) {
+                state = State.TWO_SCROLL;
+                listener.onVerticalScroll(focusDeltaY);
+            }
+        }
+        else if (state == State.TWO_PINCH) {
+            dispatchZoom(twoLastSpan, span, focusX, focusY);
+        }
+        else if (state == State.TWO_SCROLL) {
+            float deltaY = focusY - twoLastFocusY;
+            if (deltaY != 0f) {
+                listener.onVerticalScroll(deltaY);
+            }
+        }
+
+        twoLastSpan = span;
+        twoLastFocusY = focusY;
+    }
+
+    private void dispatchZoom(float previousSpan, float currentSpan, float focusX, float focusY) {
+        if (previousSpan <= 0f || currentSpan <= 0f) {
+            return;
+        }
+        float scaleFactor = currentSpan / previousSpan;
+        if (!Float.isNaN(scaleFactor) && !Float.isInfinite(scaleFactor) && scaleFactor > 0f) {
+            listener.onZoom(scaleFactor, focusX, focusY);
+        }
+    }
+
+    private void finishGesture(float x, float y, long eventTime) {
+        if (state == State.SINGLE) {
+            singleMaximumTravel = Math.max(singleMaximumTravel,
+                    distance(singleStartX, singleStartY, x, y));
+            if (isWithinTapTime(eventTime) && singleMaximumTravel <= tapMovementSlop) {
+                listener.onLeftClick();
+            }
+        }
+        else if (state == State.WAIT_FOR_ALL_UP && pendingTwoFingerTap) {
+            listener.onRightClick();
+        }
+        cancel();
+    }
+
+    private boolean isWithinTapTime(long eventTime) {
+        return eventTime - gestureDownTime <= tapTimeoutMs;
+    }
+
+    private boolean isTwoFingerState() {
+        return state == State.TWO_UNDECIDED
+                || state == State.TWO_SCROLL
+                || state == State.TWO_PINCH;
+    }
+
+    private static float distance(float x1, float y1, float x2, float y2) {
+        return (float) Math.hypot(x2 - x1, y2 - y1);
+    }
+}

--- a/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureTouchpadExtensionController.java
+++ b/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureTouchpadExtensionController.java
@@ -1,0 +1,330 @@
+package com.limelight.extensions.input.touch;
+
+import android.content.Context;
+import android.graphics.PointF;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.InputDevice;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+
+import com.limelight.nvstream.NvConnection;
+import com.limelight.nvstream.input.MouseButtonPacket;
+import com.limelight.preferences.PreferenceConfiguration;
+import com.limelight.ui.video.VideoZoomController;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED]
+ *
+ * Android adapter and remote-input sink for the dedicated multi-gesture touchpad mode.
+ */
+public final class MultiGestureTouchpadExtensionController
+        implements MultiGestureTouchContext.Listener {
+    public static final int MODE_ID = 7;
+
+    private static final int SCROLL_SPEED_FACTOR = 5;
+    private static final long TAP_TIMEOUT_MS = 250;
+    private static final long BUTTON_UP_DELAY_MS = 100;
+    private static final float PINCH_ACTIVATION_DP = 12f;
+    private static final float PINCH_ACTIVATION_RATIO = 0.05f;
+    private static final float EDGE_PAN_INSET_DP = 1f;
+    private static final float MIN_EDGE_PAN_SCALE = 1.001f;
+
+    private final NvConnection conn;
+    private final View targetView;
+    private final View coordinateView;
+    private final PreferenceConfiguration prefConfig;
+    private final VideoZoomController videoZoomController;
+    private final MultiGestureTouchContext gestureContext;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private final float[] pointerX = new float[2];
+    private final float[] pointerY = new float[2];
+    private final int[] sourceLocation = new int[2];
+    private final int[] coordinateLocation = new int[2];
+    private final PointF trackedCursorPoint = new PointF();
+    private final PointF transformedContentStart = new PointF();
+    private final PointF transformedContentEnd = new PointF();
+    private final float[] edgePanViewport = new float[4];
+    private final float[] edgePanDelta = new float[2];
+    private final MultiGestureCursorTracker cursorTracker = new MultiGestureCursorTracker();
+    private final float edgePanInsetPx;
+    private View currentSourceView;
+    private boolean ignoreUntilNextDown;
+    private boolean leftButtonDown;
+    private boolean rightButtonDown;
+    private boolean cursorSynchronized;
+    private float moveRemainderX;
+    private float moveRemainderY;
+    private float scrollRemainder;
+    private final Runnable leftButtonUp = () -> releaseButton(MouseButtonPacket.BUTTON_LEFT);
+    private final Runnable rightButtonUp = () -> releaseButton(MouseButtonPacket.BUTTON_RIGHT);
+
+    public MultiGestureTouchpadExtensionController(Context context,
+                                                   NvConnection conn,
+                                                   View targetView,
+                                                   View coordinateView,
+                                                   PreferenceConfiguration prefConfig,
+                                                   VideoZoomController videoZoomController) {
+        this.conn = conn;
+        this.targetView = targetView;
+        this.coordinateView = coordinateView;
+        this.prefConfig = prefConfig;
+        this.videoZoomController = videoZoomController;
+
+        float density = context.getResources().getDisplayMetrics().density;
+        edgePanInsetPx = EDGE_PAN_INSET_DP * density;
+        float touchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+        gestureContext = new MultiGestureTouchContext(
+                this,
+                touchSlop,
+                touchSlop,
+                PINCH_ACTIVATION_DP * density,
+                PINCH_ACTIVATION_RATIO,
+                TAP_TIMEOUT_MS);
+    }
+
+    public boolean onTouchEvent(View sourceView, MotionEvent event) {
+        if (!event.isFromSource(InputDevice.SOURCE_TOUCHSCREEN)) {
+            return false;
+        }
+
+        int action = event.getActionMasked();
+        if (ignoreUntilNextDown) {
+            if (action != MotionEvent.ACTION_DOWN) {
+                return false;
+            }
+            ignoreUntilNextDown = false;
+        }
+        if (action == MotionEvent.ACTION_DOWN) {
+            resetMotionRemainders();
+            synchronizeCursorIfNeeded();
+        }
+
+        currentSourceView = sourceView != null ? sourceView : coordinateView;
+        int coordinateCount = Math.min(event.getPointerCount(), 2);
+        for (int i = 0; i < coordinateCount; i++) {
+            pointerX[i] = event.getX(i);
+            pointerY[i] = event.getY(i);
+        }
+        return gestureContext.onTouchEvent(
+                action,
+                event.getActionIndex(),
+                event.getPointerCount(),
+                pointerX,
+                pointerY,
+                event.getEventTime());
+    }
+
+    /** Lets the existing multi-finger keyboard shortcut own the rest of the current gesture. */
+    public void cancelUntilNextGesture() {
+        gestureContext.cancel();
+        ignoreUntilNextDown = true;
+        resetMotionRemainders();
+    }
+
+    public void destroy() {
+        gestureContext.cancel();
+        handler.removeCallbacks(leftButtonUp);
+        handler.removeCallbacks(rightButtonUp);
+        releaseButton(MouseButtonPacket.BUTTON_LEFT);
+        releaseButton(MouseButtonPacket.BUTTON_RIGHT);
+        currentSourceView = null;
+    }
+
+    @Override
+    public void onPointerMove(float deltaX, float deltaY) {
+        int targetWidth = Math.max(targetView.getWidth(), 1);
+        int targetHeight = Math.max(targetView.getHeight(), 1);
+        View sourceView = currentSourceView != null ? currentSourceView : coordinateView;
+        // MotionEvent coordinates are inverse-transformed into a scaled child. Restore physical
+        // finger travel so mouse sensitivity remains stable at every video zoom level.
+        float scaledX = deltaX * sourceView.getScaleX()
+                * MultiGestureCursorTracker.REFERENCE_WIDTH / targetWidth;
+        float scaledY = deltaY * sourceView.getScaleY()
+                * MultiGestureCursorTracker.REFERENCE_HEIGHT / targetHeight;
+
+        scaledX *= prefConfig.mouseTouchPadSensitityX * 0.01f;
+        scaledY *= prefConfig.mouseTouchPadSensitityY * 0.01f;
+
+        int outputX = consumeRoundedX(scaledX);
+        int outputY = consumeRoundedY(scaledY);
+        if (outputX == 0 && outputY == 0) {
+            return;
+        }
+
+        synchronizeCursorIfNeeded();
+        cursorTracker.move(clampToShort(outputX), clampToShort(outputY));
+        sendTrackedCursorPosition();
+        panForTrackedCursor();
+    }
+
+    @Override
+    public void onVerticalScroll(float deltaY) {
+        int targetHeight = Math.max(targetView.getHeight(), 1);
+        View sourceView = currentSourceView != null ? currentSourceView : coordinateView;
+        float scaledDelta = deltaY * sourceView.getScaleY()
+                * MultiGestureCursorTracker.REFERENCE_HEIGHT / targetHeight
+                * SCROLL_SPEED_FACTOR + scrollRemainder;
+        int output = Math.round(scaledDelta);
+        scrollRemainder = scaledDelta - output;
+        if (output != 0) {
+            conn.sendMouseHighResScroll(clampToShort(output));
+        }
+    }
+
+    @Override
+    public void onZoom(float scaleFactor, float focusX, float focusY) {
+        if (videoZoomController == null) {
+            return;
+        }
+
+        View sourceView = currentSourceView != null ? currentSourceView : coordinateView;
+        sourceView.getLocationInWindow(sourceLocation);
+        coordinateView.getLocationInWindow(coordinateLocation);
+        // VideoZoomController uses a zero pivot. Touch coordinates delivered to a transformed
+        // child are local/unscaled, so restore the child's visual scale before converting them
+        // into the controller's coordinate view.
+        float coordinateFocusX = focusX * sourceView.getScaleX()
+                + sourceLocation[0] - coordinateLocation[0];
+        float coordinateFocusY = focusY * sourceView.getScaleY()
+                + sourceLocation[1] - coordinateLocation[1];
+        videoZoomController.scaleBy(scaleFactor, coordinateFocusX, coordinateFocusY);
+    }
+
+    @Override
+    public void onLeftClick() {
+        clickButton(MouseButtonPacket.BUTTON_LEFT);
+    }
+
+    @Override
+    public void onRightClick() {
+        clickButton(MouseButtonPacket.BUTTON_RIGHT);
+    }
+
+    private int consumeRoundedX(float delta) {
+        float value = delta + moveRemainderX;
+        int output = Math.round(value);
+        moveRemainderX = value - output;
+        return output;
+    }
+
+    private int consumeRoundedY(float delta) {
+        float value = delta + moveRemainderY;
+        int output = Math.round(value);
+        moveRemainderY = value - output;
+        return output;
+    }
+
+    private void resetMotionRemainders() {
+        moveRemainderX = 0f;
+        moveRemainderY = 0f;
+        scrollRemainder = 0f;
+    }
+
+    private void panForTrackedCursor() {
+        if (videoZoomController == null
+                || videoZoomController.getScale() <= MIN_EDGE_PAN_SCALE
+                || !videoZoomController.mapNormalizedVideoToPoint(
+                        cursorTracker.getNormalizedX(), cursorTracker.getNormalizedY(),
+                        trackedCursorPoint)
+                || !videoZoomController.mapNormalizedVideoToPoint(
+                        0f, 0f, transformedContentStart)
+                || !videoZoomController.mapNormalizedVideoToPoint(
+                        1f, 1f, transformedContentEnd)) {
+            return;
+        }
+
+        // Zoomed content may extend beyond the original video rectangle. Use the full gesture
+        // coordinate viewport as the trigger aperture, while preserving any bottom area reserved
+        // by the IME accessory extension through the video view's layout margin.
+        MultiGestureViewportCalculator.calculate(
+                coordinateView.getWidth(),
+                coordinateView.getHeight(),
+                getReservedBottomInset(),
+                edgePanViewport);
+        MultiGestureEdgePanCalculator.calculate(
+                trackedCursorPoint.x,
+                trackedCursorPoint.y,
+                edgePanViewport[MultiGestureViewportCalculator.LEFT],
+                edgePanViewport[MultiGestureViewportCalculator.TOP],
+                edgePanViewport[MultiGestureViewportCalculator.RIGHT],
+                edgePanViewport[MultiGestureViewportCalculator.BOTTOM],
+                transformedContentStart.x,
+                transformedContentStart.y,
+                transformedContentEnd.x,
+                transformedContentEnd.y,
+                edgePanInsetPx,
+                edgePanDelta);
+        if (edgePanDelta[0] != 0f || edgePanDelta[1] != 0f) {
+            videoZoomController.panBy(edgePanDelta[0], edgePanDelta[1]);
+        }
+    }
+
+    private int getReservedBottomInset() {
+        if (targetView.getParent() != coordinateView) {
+            return 0;
+        }
+
+        ViewGroup.LayoutParams rawLayoutParams = targetView.getLayoutParams();
+        if (!(rawLayoutParams instanceof ViewGroup.MarginLayoutParams)) {
+            return 0;
+        }
+
+        return Math.max(0, ((ViewGroup.MarginLayoutParams) rawLayoutParams).bottomMargin);
+    }
+
+    private void synchronizeCursorIfNeeded() {
+        if (cursorSynchronized) {
+            return;
+        }
+        sendTrackedCursorPosition();
+        cursorSynchronized = true;
+    }
+
+    private void sendTrackedCursorPosition() {
+        conn.sendMousePosition(
+                cursorTracker.getReferenceX(),
+                cursorTracker.getReferenceY(),
+                MultiGestureCursorTracker.REFERENCE_WIDTH,
+                MultiGestureCursorTracker.REFERENCE_HEIGHT);
+    }
+
+    private void clickButton(byte button) {
+        Runnable buttonUp;
+        if (button == MouseButtonPacket.BUTTON_LEFT) {
+            handler.removeCallbacks(leftButtonUp);
+            leftButtonDown = true;
+            buttonUp = leftButtonUp;
+        }
+        else {
+            handler.removeCallbacks(rightButtonUp);
+            rightButtonDown = true;
+            buttonUp = rightButtonUp;
+        }
+        conn.sendMouseButtonDown(button);
+        handler.postDelayed(buttonUp, BUTTON_UP_DELAY_MS);
+    }
+
+    private void releaseButton(byte button) {
+        if (button == MouseButtonPacket.BUTTON_LEFT) {
+            if (!leftButtonDown) {
+                return;
+            }
+            leftButtonDown = false;
+        }
+        else {
+            if (!rightButtonDown) {
+                return;
+            }
+            rightButtonDown = false;
+        }
+        conn.sendMouseButtonUp(button);
+    }
+
+    private static short clampToShort(int value) {
+        return (short) Math.max(Short.MIN_VALUE, Math.min(Short.MAX_VALUE, value));
+    }
+
+}

--- a/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureViewportCalculator.java
+++ b/app/src/main/java/com/limelight/extensions/input/touch/MultiGestureViewportCalculator.java
@@ -1,0 +1,32 @@
+package com.limelight.extensions.input.touch;
+
+/**
+ * EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED]
+ *
+ * Resolves the screen-space viewport used for edge following. The untransformed video rectangle
+ * is content geometry, not the visible aperture after zoom, so it must not define trigger edges.
+ */
+final class MultiGestureViewportCalculator {
+    static final int LEFT = 0;
+    static final int TOP = 1;
+    static final int RIGHT = 2;
+    static final int BOTTOM = 3;
+
+    private MultiGestureViewportCalculator() {
+    }
+
+    static void calculate(float coordinateWidth, float coordinateHeight,
+                          float reservedBottomInset, float[] outBounds) {
+        if (outBounds == null || outBounds.length < 4) {
+            throw new IllegalArgumentException("outBounds must contain at least four elements");
+        }
+
+        float width = Math.max(coordinateWidth, 1f);
+        float height = Math.max(coordinateHeight, 1f);
+        float bottomInset = Math.max(0f, Math.min(reservedBottomInset, height - 1f));
+        outBounds[LEFT] = 0f;
+        outBounds[TOP] = 0f;
+        outBounds[RIGHT] = width;
+        outBounds[BOTTOM] = height - bottomInset;
+    }
+}

--- a/app/src/main/java/com/limelight/ui/gamemenu/GameMenuFragment.java
+++ b/app/src/main/java/com/limelight/ui/gamemenu/GameMenuFragment.java
@@ -370,33 +370,40 @@ public class GameMenuFragment extends BaseGameMenuDialog implements View.OnClick
             return;
         }
         if(v.getId()==R.id.bt_touch_list){
+            // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+            // Keep actions appended after the mouse modes stable when extensions add modes.
+            final int mouseModeCount = getResources()
+                    .getStringArray(R.array.mouse_model_names_axi).length;
+            // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
             GameListMouseFragment fragment=new GameListMouseFragment();
             fragment.setWidth(UiHelper.dpToPx(getActivity(),364));
             fragment.setTitle("鼠标与触控");
             fragment.setOnClick(new GameListMouseFragment.onClick() {
                 @Override
                 public void click(String title, int index) {
-                    if(!TextUtils.isEmpty(title)&&index!=8){
+                    // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+                    if(!TextUtils.isEmpty(title)&&index!=mouseModeCount + 1){
                         Toast.makeText(getActivity(),title,Toast.LENGTH_SHORT).show();
                     }
                     if(game==null||index<0){
                         return;
                     }
-                    if(index==7){
+                    if(index==mouseModeCount){
                         game.switchMouseLocalCursor();
                         return;
                     }
-                    if(index==8){
+                    if(index==mouseModeCount + 1){
                         game.prefConfig.absoluteMouseMode=!game.prefConfig.absoluteMouseMode;
                         Toast.makeText(getActivity(),"远程桌面鼠标模式"+(game.prefConfig.absoluteMouseMode?"已启用！":"已禁用！"),Toast.LENGTH_SHORT).show();
                         return;
                     }
-                    if(index==9){
+                    if(index==mouseModeCount + 2){
                         if(conn!=null){
                             sendKeys(new short[]{KeyboardTranslator.VK_LCONTROL,KeyboardTranslator.VK_LMENU, KeyboardTranslator.VK_LSHIFT, KeyboardTranslator.VK_N});
                         }
                         return;
                     }
+                    // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
                     game.switchMouseModel(index);
                 }
             });

--- a/app/src/main/java/com/limelight/ui/video/VideoZoomController.java
+++ b/app/src/main/java/com/limelight/ui/video/VideoZoomController.java
@@ -135,6 +135,23 @@ public final class VideoZoomController {
         return true;
     }
 
+    // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN
+    /** Maps a normalized remote-video cursor position into the transformed local viewport. */
+    public boolean mapNormalizedVideoToPoint(float normalizedX, float normalizedY,
+                                             PointF outPoint) {
+        if (!updateBaseVideoRect() || baseVideoRect.width() <= 0f || baseVideoRect.height() <= 0f) {
+            return false;
+        }
+
+        outPoint.set(
+                baseVideoRect.left + clamp(normalizedX, 0f, 1f) * baseVideoRect.width() * scale
+                        + panX + externalOffsetX,
+                baseVideoRect.top + clamp(normalizedY, 0f, 1f) * baseVideoRect.height() * scale
+                        + panY + externalOffsetY);
+        return true;
+    }
+    // EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END
+
     public void destroy() {
         scale = MIN_SCALE;
         panX = 0f;

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -253,6 +253,9 @@
         <item>普通鼠标「左右键互换」</item>
         <item>触控板「仅移动」</item>
         <item>触控板「移动+左键点击」</item>
+        <!-- EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN -->
+        <item>触控板「多手势」</item>
+        <!-- EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END -->
     </string-array>
 
     <string-array name="mouse_model_values_axi" translatable="false">
@@ -263,6 +266,9 @@
         <item>4</item>
         <item>5</item>
         <item>6</item>
+        <!-- EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] BEGIN -->
+        <item>7</item>
+        <!-- EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [MODIFIED] END -->
     </string-array>
 
 

--- a/app/src/test/java/com/limelight/extensions/input/touch/MultiGestureCursorTrackerTest.java
+++ b/app/src/test/java/com/limelight/extensions/input/touch/MultiGestureCursorTrackerTest.java
@@ -1,0 +1,42 @@
+package com.limelight.extensions.input.touch;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/** EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED] */
+public class MultiGestureCursorTrackerTest {
+    @Test
+    public void startsAtCenterOfReferencePlane() {
+        MultiGestureCursorTracker tracker = new MultiGestureCursorTracker();
+
+        assertEquals(640, tracker.getReferenceX());
+        assertEquals(360, tracker.getReferenceY());
+        assertEquals(640f / 1279f, tracker.getNormalizedX(), 0.001f);
+        assertEquals(360f / 719f, tracker.getNormalizedY(), 0.001f);
+    }
+
+    @Test
+    public void movementUsesSharedAbsoluteReferencePlane() {
+        MultiGestureCursorTracker tracker = new MultiGestureCursorTracker();
+
+        tracker.move((short) 320, (short) -180);
+
+        assertEquals(960, tracker.getReferenceX());
+        assertEquals(180, tracker.getReferenceY());
+        assertEquals(960f / 1279f, tracker.getNormalizedX(), 0.001f);
+        assertEquals(180f / 719f, tracker.getNormalizedY(), 0.001f);
+    }
+
+    @Test
+    public void movementClampsAtReferencePlaneEdges() {
+        MultiGestureCursorTracker tracker = new MultiGestureCursorTracker();
+
+        tracker.move(Short.MAX_VALUE, Short.MIN_VALUE);
+
+        assertEquals(1279, tracker.getReferenceX());
+        assertEquals(0, tracker.getReferenceY());
+        assertEquals(1f, tracker.getNormalizedX(), 0.001f);
+        assertEquals(0f, tracker.getNormalizedY(), 0.001f);
+    }
+}

--- a/app/src/test/java/com/limelight/extensions/input/touch/MultiGestureEdgePanCalculatorTest.java
+++ b/app/src/test/java/com/limelight/extensions/input/touch/MultiGestureEdgePanCalculatorTest.java
@@ -1,0 +1,120 @@
+package com.limelight.extensions.input.touch;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+/** EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED] */
+public class MultiGestureEdgePanCalculatorTest {
+    private final float[] delta = new float[2];
+
+    @Test
+    public void cursorInsideSafeAreaDoesNotPan() {
+        calculate(500f, 300f);
+
+        assertArrayEquals(new float[] {0f, 0f}, delta, 0.001f);
+    }
+
+    @Test
+    public void cursorNearRightEdgePansVideoLeft() {
+        calculate(990f, 300f);
+
+        assertArrayEquals(new float[] {-22f, 0f}, delta, 0.001f);
+    }
+
+    @Test
+    public void cursorNearTopLeftCornerPansVideoDownAndRight() {
+        calculate(10f, 12f);
+
+        assertArrayEquals(new float[] {22f, 20f}, delta, 0.001f);
+    }
+
+    @Test
+    public void cursorNearBottomEdgePansVideoUp() {
+        calculate(500f, 595f);
+
+        assertArrayEquals(new float[] {0f, -27f}, delta, 0.001f);
+    }
+
+    @Test
+    public void originalVideoEdgeIsNotAViewportEdgeAfterZoom() {
+        MultiGestureEdgePanCalculator.calculate(
+                500f, 650f,
+                0f, 0f, 1000f, 2000f,
+                -200f, -100f, 1200f, 2100f,
+                1f, delta);
+
+        assertArrayEquals(new float[] {0f, 0f}, delta, 0.001f);
+    }
+
+    @Test
+    public void oneDpInsetWaitsUntilCursorReachesBottomEdge() {
+        MultiGestureEdgePanCalculator.calculate(
+                500f, 598f,
+                0f, 0f, 1000f, 600f,
+                -200f, -100f, 1200f, 700f,
+                1f, delta);
+
+        assertArrayEquals(new float[] {0f, 0f}, delta, 0.001f);
+
+        MultiGestureEdgePanCalculator.calculate(
+                500f, 600f,
+                0f, 0f, 1000f, 600f,
+                -200f, -100f, 1200f, 700f,
+                1f, delta);
+
+        assertArrayEquals(new float[] {0f, -1f}, delta, 0.001f);
+    }
+
+    @Test
+    public void imeReducedViewportUsesAccessoryBarTopAsBottomEdge() {
+        MultiGestureEdgePanCalculator.calculate(
+                500f, 395f,
+                0f, 0f, 1000f, 400f,
+                -200f, -100f, 1200f, 600f,
+                32f, delta);
+
+        assertArrayEquals(new float[] {0f, -27f}, delta, 0.001f);
+    }
+
+    @Test
+    public void cursorAtUnoccludedLeftEdgeDoesNotPan() {
+        MultiGestureEdgePanCalculator.calculate(
+                10f, 300f,
+                0f, 0f, 1000f, 600f,
+                0f, -100f, 1200f, 700f,
+                32f, delta);
+
+        assertArrayEquals(new float[] {0f, 0f}, delta, 0.001f);
+    }
+
+    @Test
+    public void cursorAtUnoccludedRightEdgeDoesNotPan() {
+        MultiGestureEdgePanCalculator.calculate(
+                990f, 300f,
+                0f, 0f, 1000f, 600f,
+                -200f, -100f, 1000f, 700f,
+                32f, delta);
+
+        assertArrayEquals(new float[] {0f, 0f}, delta, 0.001f);
+    }
+
+    @Test
+    public void panDeltaDoesNotExceedHiddenContentDistance() {
+        MultiGestureEdgePanCalculator.calculate(
+                10f, 300f,
+                0f, 0f, 1000f, 600f,
+                -5f, -100f, 1200f, 700f,
+                32f, delta);
+
+        assertArrayEquals(new float[] {5f, 0f}, delta, 0.001f);
+    }
+
+    private void calculate(float cursorX, float cursorY) {
+        MultiGestureEdgePanCalculator.calculate(
+                cursorX, cursorY,
+                0f, 0f, 1000f, 600f,
+                -200f, -100f, 1200f, 700f,
+                32f, delta);
+    }
+}

--- a/app/src/test/java/com/limelight/extensions/input/touch/MultiGestureTouchContextTest.java
+++ b/app/src/test/java/com/limelight/extensions/input/touch/MultiGestureTouchContextTest.java
@@ -1,0 +1,179 @@
+package com.limelight.extensions.input.touch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED] */
+public class MultiGestureTouchContextTest {
+    private RecordingListener listener;
+    private MultiGestureTouchContext context;
+
+    @Before
+    public void setUp() {
+        listener = new RecordingListener();
+        context = new MultiGestureTouchContext(listener,
+                8f, 8f, 12f, 0.05f, 250);
+    }
+
+    @Test
+    public void singleFingerTapSendsLeftClick() {
+        event(MultiGestureTouchContext.ACTION_DOWN, 0, 1, 0, xy(100), xy(100));
+        event(MultiGestureTouchContext.ACTION_UP, 0, 1, 100, xy(103), xy(104));
+
+        assertEquals(1, listener.leftClicks);
+        assertEquals(0, listener.rightClicks);
+    }
+
+    @Test
+    public void singleFingerMoveMovesPointerWithoutClicking() {
+        event(MultiGestureTouchContext.ACTION_DOWN, 0, 1, 0, xy(100), xy(100));
+        event(MultiGestureTouchContext.ACTION_MOVE, 0, 1, 30, xy(120), xy(130));
+        event(MultiGestureTouchContext.ACTION_UP, 0, 1, 80, xy(120), xy(130));
+
+        assertEquals(1, listener.moves.size());
+        assertEquals(20f, listener.moves.get(0)[0], 0.001f);
+        assertEquals(30f, listener.moves.get(0)[1], 0.001f);
+        assertEquals(0, listener.leftClicks);
+    }
+
+    @Test
+    public void twoFingerTapSendsRightClickWhenPrimaryFingerLiftsFirst() {
+        performTwoFingerTap(0);
+
+        assertEquals(1, listener.rightClicks);
+        assertEquals(0, listener.leftClicks);
+    }
+
+    @Test
+    public void twoFingerTapSendsRightClickWhenSecondaryFingerLiftsFirst() {
+        performTwoFingerTap(1);
+
+        assertEquals(1, listener.rightClicks);
+        assertEquals(0, listener.leftClicks);
+    }
+
+    @Test
+    public void parallelTwoFingerVerticalMovementScrollsWithoutZoomingOrClicking() {
+        beginTwoFingerGesture();
+        event(MultiGestureTouchContext.ACTION_MOVE, 0, 2, 50,
+                xy(100, 200), xy(125, 125));
+        event(MultiGestureTouchContext.ACTION_MOVE, 0, 2, 70,
+                xy(100, 200), xy(135, 135));
+        finishTwoFingerGesture(100);
+
+        assertEquals(2, listener.scrolls.size());
+        assertEquals(25f, listener.scrolls.get(0), 0.001f);
+        assertEquals(10f, listener.scrolls.get(1), 0.001f);
+        assertTrue(listener.zooms.isEmpty());
+        assertEquals(0, listener.rightClicks);
+    }
+
+    @Test
+    public void spreadingTwoFingersZoomsInWithoutScrolling() {
+        beginTwoFingerGesture();
+        event(MultiGestureTouchContext.ACTION_MOVE, 0, 2, 50,
+                xy(85, 215), xy(100, 100));
+
+        assertEquals(1, listener.zooms.size());
+        assertEquals(1.3f, listener.zooms.get(0)[0], 0.001f);
+        assertTrue(listener.scrolls.isEmpty());
+    }
+
+    @Test
+    public void pinchingTwoFingersZoomsOutWithoutScrolling() {
+        beginTwoFingerGesture();
+        event(MultiGestureTouchContext.ACTION_MOVE, 0, 2, 50,
+                xy(115, 185), xy(100, 100));
+
+        assertEquals(1, listener.zooms.size());
+        assertEquals(0.7f, listener.zooms.get(0)[0], 0.001f);
+        assertTrue(listener.scrolls.isEmpty());
+    }
+
+    @Test
+    public void oneRemainingFingerIsIgnoredUntilGestureFullyEnds() {
+        beginTwoFingerGesture();
+        event(MultiGestureTouchContext.ACTION_MOVE, 0, 2, 50,
+                xy(100, 200), xy(120, 120));
+        event(MultiGestureTouchContext.ACTION_POINTER_UP, 0, 2, 70,
+                xy(100, 200), xy(120, 120));
+        event(MultiGestureTouchContext.ACTION_MOVE, 0, 1, 80,
+                xy(240), xy(240));
+        event(MultiGestureTouchContext.ACTION_UP, 0, 1, 100,
+                xy(240), xy(240));
+
+        assertTrue(listener.moves.isEmpty());
+        assertEquals(0, listener.leftClicks);
+        assertEquals(0, listener.rightClicks);
+    }
+
+    private void performTwoFingerTap(int liftedPointerIndex) {
+        beginTwoFingerGesture();
+        event(MultiGestureTouchContext.ACTION_POINTER_UP, liftedPointerIndex, 2, 80,
+                xy(100, 200), xy(100, 100));
+        event(MultiGestureTouchContext.ACTION_UP, 0, 1, 120,
+                xy(liftedPointerIndex == 0 ? 200 : 100), xy(100));
+    }
+
+    private void beginTwoFingerGesture() {
+        event(MultiGestureTouchContext.ACTION_DOWN, 0, 1, 0,
+                xy(100), xy(100));
+        event(MultiGestureTouchContext.ACTION_POINTER_DOWN, 1, 2, 20,
+                xy(100, 200), xy(100, 100));
+    }
+
+    private void finishTwoFingerGesture(long eventTime) {
+        event(MultiGestureTouchContext.ACTION_POINTER_UP, 1, 2, eventTime,
+                xy(100, 200), xy(135, 135));
+        event(MultiGestureTouchContext.ACTION_UP, 0, 1, eventTime + 20,
+                xy(100), xy(135));
+    }
+
+    private void event(int action, int actionIndex, int pointerCount, long eventTime,
+                       float[] x, float[] y) {
+        assertTrue(context.onTouchEvent(action, actionIndex, pointerCount, x, y, eventTime));
+    }
+
+    private static float[] xy(float... values) {
+        return values;
+    }
+
+    private static final class RecordingListener implements MultiGestureTouchContext.Listener {
+        final List<float[]> moves = new ArrayList<>();
+        final List<Float> scrolls = new ArrayList<>();
+        final List<float[]> zooms = new ArrayList<>();
+        int leftClicks;
+        int rightClicks;
+
+        @Override
+        public void onPointerMove(float deltaX, float deltaY) {
+            moves.add(new float[] {deltaX, deltaY});
+        }
+
+        @Override
+        public void onVerticalScroll(float deltaY) {
+            scrolls.add(deltaY);
+        }
+
+        @Override
+        public void onZoom(float scaleFactor, float focusX, float focusY) {
+            zooms.add(new float[] {scaleFactor, focusX, focusY});
+        }
+
+        @Override
+        public void onLeftClick() {
+            leftClicks++;
+        }
+
+        @Override
+        public void onRightClick() {
+            rightClicks++;
+        }
+    }
+}

--- a/app/src/test/java/com/limelight/extensions/input/touch/MultiGestureViewportCalculatorTest.java
+++ b/app/src/test/java/com/limelight/extensions/input/touch/MultiGestureViewportCalculatorTest.java
@@ -1,0 +1,31 @@
+package com.limelight.extensions.input.touch;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+/** EXTENSION DEVELOPMENT [EXT-TOUCHPAD-MULTI-GESTURE] [ADDED] */
+public class MultiGestureViewportCalculatorTest {
+    private final float[] bounds = new float[4];
+
+    @Test
+    public void noOcclusionUsesFullGestureViewport() {
+        MultiGestureViewportCalculator.calculate(1080f, 2400f, 0f, bounds);
+
+        assertArrayEquals(new float[] {0f, 0f, 1080f, 2400f}, bounds, 0.001f);
+    }
+
+    @Test
+    public void accessoryReservationMovesOnlyBottomEdge() {
+        MultiGestureViewportCalculator.calculate(1080f, 2400f, 484f, bounds);
+
+        assertArrayEquals(new float[] {0f, 0f, 1080f, 1916f}, bounds, 0.001f);
+    }
+
+    @Test
+    public void excessiveBottomReservationKeepsViewportValid() {
+        MultiGestureViewportCalculator.calculate(1080f, 2400f, 3000f, bounds);
+
+        assertArrayEquals(new float[] {0f, 0f, 1080f, 1f}, bounds, 0.001f);
+    }
+}

--- a/dev/extensions/EXT-TOUCHPAD-MULTI-GESTURE.md
+++ b/dev/extensions/EXT-TOUCHPAD-MULTI-GESTURE.md
@@ -1,0 +1,49 @@
+# EXT-TOUCHPAD-MULTI-GESTURE
+
+- Change type: extension development
+- Status: experimental
+- Added: 2026-08-24
+- Purpose: provide an isolated `触控板「多手势」` mouse/touch mode with single-finger movement
+  and tap, two-finger tap and vertical scroll, pinch zoom, and cursor-following edge pan.
+- Added files:
+  - `app/src/main/java/com/limelight/extensions/input/touch/MultiGestureCursorTracker.java`
+  - `app/src/main/java/com/limelight/extensions/input/touch/MultiGestureEdgePanCalculator.java`
+  - `app/src/main/java/com/limelight/extensions/input/touch/MultiGestureTouchContext.java`
+  - `app/src/main/java/com/limelight/extensions/input/touch/MultiGestureTouchpadExtensionController.java`
+  - `app/src/main/java/com/limelight/extensions/input/touch/MultiGestureViewportCalculator.java`
+- Added test files:
+  - `app/src/test/java/com/limelight/extensions/input/touch/MultiGestureCursorTrackerTest.java`
+  - `app/src/test/java/com/limelight/extensions/input/touch/MultiGestureEdgePanCalculatorTest.java`
+  - `app/src/test/java/com/limelight/extensions/input/touch/MultiGestureTouchContextTest.java`
+  - `app/src/test/java/com/limelight/extensions/input/touch/MultiGestureViewportCalculatorTest.java`
+- Modified files:
+  - `app/src/main/java/com/limelight/Game.java`
+  - `app/src/main/java/com/limelight/ui/gamemenu/GameMenuFragment.java`
+  - `app/src/main/java/com/limelight/ui/video/VideoZoomController.java`
+  - `app/src/main/res/values/arrays.xml`
+- Gesture classification: each two-finger gesture starts undecided, then locks to vertical scroll or
+  pinch zoom after crossing its threshold. The classification remains locked until every finger is
+  lifted, preventing zoom/scroll crossover and one-finger jumps after a two-finger action.
+- Input mapping: one-finger motion updates the mode-owned absolute cursor; one-finger tap sends
+  left-click; two-finger tap sends right-click regardless of finger release order; vertical motion
+  sends host scroll; pinch and spread update the existing session-local video transform.
+- Upstream isolation: the new mode has its own stable value (`7`) and a single public Android
+  controller. Its cursor tracker, gesture state machine, and geometry calculators remain
+  package-private. Existing mode values and touch-context implementations are unchanged.
+- Merge-order isolation: this extension has no Java or resource dependency on the IME accessory,
+  ASCII input, or IME viewport extensions. It reads an optional bottom layout margin through the
+  existing video view, so the IME viewport extension can be merged before, after, or not at all.
+- Overlay compatibility: the standalone zoom and virtual-mouse touch layers are suppressed while
+  this mode owns touchscreen gestures, without resetting the current video transform.
+- Edge following: at zoom levels above 1x, the extension pans only when its tracked cursor reaches
+  an edge with transformed video content hidden beyond it. The trigger aperture is the actual
+  gesture viewport; an optional bottom layout reservation moves only the bottom trigger edge.
+- Absolute-cursor isolation: this mode owns a 1280x720 logical cursor plane independently of the
+  global remote-desktop mouse setting. This is packet reference geometry, not stream resolution.
+  The first touchscreen contact synchronizes the host cursor to the logical center, and subsequent
+  one-finger movement sends absolute positions from the tracker also used by edge following.
+- Edge-follow limitation: the streaming protocol does not return the current remote cursor position
+  to this Java input path. Host-side cursor warps or simultaneous physical-mouse input can desync the
+  tracked position; selecting the mode again resets the tracker to the video center.
+- Menu compatibility: appended game-menu actions use the resource-defined mode count instead of
+  fixed indexes, so adding this mode does not redirect those actions.

--- a/dev/extensions/README.md
+++ b/dev/extensions/README.md
@@ -1,0 +1,20 @@
+# Extension development registry
+
+Project-local extensions use stable markers so their owned files and upstream integration points
+remain easy to locate during review:
+
+```text
+EXTENSION DEVELOPMENT [<extension-id>] [ADDED|MODIFIED]
+```
+
+- `ADDED` marks a file created and owned by an extension.
+- `MODIFIED` marks an integration point in an existing upstream file. Modified blocks use matching
+  `BEGIN` and `END` markers.
+- Each extension has an independent detail file in this directory so unrelated extensions can be
+  reviewed and merged separately.
+
+Locate all registered extension changes with:
+
+```bash
+rg -n "EXTENSION DEVELOPMENT \[EXT-[^]]+\]" app/src dev/extensions
+```


### PR DESCRIPTION
## 修改说明

新增独立的 `触控板「多手势」` 模式，在不改变现有鼠标与触控模式行为的前提下，提供以下操作：

- 单指移动：移动模式自有的绝对鼠标光标
- 单指轻触：鼠标左键
- 双指轻触：鼠标右键
- 双指上下滑动：页面滚动
- 双指捏合/分开：缩小或放大串流画面
- 画面放大后，光标触及可视区域边缘时自动推移画面

## 手势判定

双指操作开始时先进入待判定状态，超过对应阈值后锁定为滚动或缩放，直到所有手指抬起。

这样可以避免：

- 缩放过程中误触发滚动
- 滚动过程中切换成缩放
- 双指操作结束后出现单指光标跳动
- 双指抬起顺序不同导致右键失效

## 边缘推移

边缘判断以当前实际可视区域为准，而不是以未缩放的视频矩形为准：

- 仅在缩放比例大于 `1x` 时启用
- 仅当对应方向仍有画面被遮挡时才允许推移
- 未被遮挡的方向不会提前触发
- 调起软键盘并预留底部区域时，底部触发边界自动移动到预留区域上方
- 未安装或未合并软键盘按键栏扩展时，底部预留值为 `0`，不影响正常行为

`1280x720` 只作为该模式发送绝对鼠标数据时的逻辑参考坐标系，不会修改串流分辨率、解码尺寸或被控端显示分辨率。

## 扩展隔离

本次修改按照扩展开发方式组织：

- 扩展 ID：`EXT-TOUCHPAD-MULTI-GESTURE`
- 扩展实现集中在 `com.limelight.extensions.input.touch`
- 仅 `MultiGestureTouchpadExtensionController` 作为公开接入控制器
- 光标跟踪器、手势状态机和几何计算器保持包内可见
- 扩展自有文件使用 `[ADDED]` 标记
- 上游接入点使用配对的 `[MODIFIED] BEGIN/END` 标记
- 现有触控模式编号和输入实现保持不变
- 菜单附加操作改为根据资源中的模式数量计算索引，避免新增模式改变原有菜单行为

## 与其他 PR 的关系

本 PR 直接基于上游 `master` 创建，不依赖以下扩展：

- `EXT-IME-ACCESSORY-BAR`
- `EXT-IME-ASCII-INPUT`
- `EXT-IME-VIDEO-VIEWPORT`

三个 PR 可以按照任意顺序合并：

- 不引用前两个 PR 新增的 Java 类或资源
- 使用独立的扩展目录和扩展说明文件
- 共享的扩展规范文件保持相同基础内容
- `Game.java` 中使用独立且配对的扩展接入标记
- 软键盘底部预留通过现有 View 布局参数读取，不形成编译或运行依赖

已通过 Git 三方合并验证全部 6 种合并顺序，均未产生冲突。

## 测试

在项目提供的 Ubuntu 26.04 开发镜像中执行：

```bash
gradle --no-daemon \
  testNonRootDebugUnitTest \
  --tests "com.limelight.extensions.input.touch.*" \
  assembleNonRootDebug
```

验证结果：

- 多手势相关单元测试：24/24 通过
- `assembleNonRootDebug`：通过
- Java 与四个 Android NDK ABI：编译通过
- `git diff --check`：通过

## 已知限制

当前 Java 输入路径无法从串流协议获取被控端鼠标的实时位置。

如果被控端主动改变光标位置，或者同时使用物理鼠标，远端光标可能与该模式自有的光标跟踪位置不同。重新选择 `触控板「多手势」` 模式后，会将跟踪位置和被控端光标同步到画面中心。
